### PR TITLE
Add comprehensive log management to prevent disk exhaustion

### DIFF
--- a/roles/regluit_prod/handlers/main.yml
+++ b/roles/regluit_prod/handlers/main.yml
@@ -1,6 +1,12 @@
 ---
 - name: restart apache
   become: yes
-  service: 
+  service:
     name: apache2
+    state: restarted
+
+- name: restart journald
+  become: yes
+  ansible.builtin.service:
+    name: systemd-journald
     state: restarted

--- a/roles/regluit_prod/tasks/cron.yml
+++ b/roles/regluit_prod/tasks/cron.yml
@@ -1,6 +1,6 @@
 ---
 # Cron jobs for log cleanup and maintenance
-# See: https://github.com/Gluejar/regluit/issues/1073
+# See: https://github.com/Gluejar/regluit/issues/1111 (disk/log management)
 # See: https://github.com/Gluejar/regluit/issues/1078 (bot traffic)
 
 # Workaround for memory pressure under heavy bot traffic
@@ -14,11 +14,69 @@
     job: "service apache2 restart"
     user: root
 
-- name: Clean up old Apache logs (older than 14 days)
+# Apache access logs can reach 1GB/day under bot traffic.
+# cronolog creates dated files but doesn't clean them up.
+- name: Clean up old Apache logs (uncompressed older than 7 days)
   become: yes
   ansible.builtin.cron:
     name: "apache-log-cleanup"
     minute: "0"
     hour: "3"
-    job: "find /var/log/apache2 -name '*.log' -mtime +14 -delete"
+    job: "find /var/log/apache2 -name '*.log' -mtime +7 -delete"
     user: root
+
+- name: Clean up old Apache logs (compressed older than 14 days)
+  become: yes
+  ansible.builtin.cron:
+    name: "apache-log-cleanup-gz"
+    minute: "5"
+    hour: "3"
+    job: "find /var/log/apache2 -name '*.log.gz' -mtime +14 -delete"
+    user: root
+
+- name: Compress Apache logs older than 2 days
+  become: yes
+  ansible.builtin.cron:
+    name: "apache-log-compress"
+    minute: "10"
+    hour: "3"
+    job: "find /var/log/apache2 -name '*.log' -mtime +2 ! -name '$(date +\\%Y\\%m\\%d)_*' -exec gzip -q {} \\;"
+    user: root
+
+# Celery worker log grows unbounded — truncate weekly
+- name: Truncate celery worker log weekly
+  become: yes
+  ansible.builtin.cron:
+    name: "celery-log-truncate"
+    minute: "15"
+    hour: "3"
+    weekday: "0"
+    job: "tail -5000 /var/log/celery/w1.log > /var/log/celery/w1.log.tmp && mv /var/log/celery/w1.log.tmp /var/log/celery/w1.log && chown celery:www-data /var/log/celery/w1.log"
+    user: root
+
+# Clean up old celery metrics HTML files (older than 30 days)
+- name: Clean up old celery metrics
+  become: yes
+  ansible.builtin.cron:
+    name: "celery-metrics-cleanup"
+    minute: "20"
+    hour: "3"
+    job: "find /var/log/celery -name 'metrics-*.html' -mtime +30 -delete"
+    user: root
+
+# Clean up old regluit app logs (older than 30 days)
+- name: Clean up old regluit app logs
+  become: yes
+  ansible.builtin.cron:
+    name: "regluit-log-cleanup"
+    minute: "25"
+    hour: "3"
+    job: "find /var/log/regluit -name '*.log' -mtime +30 -delete && find /var/log/regluit -name '*.log.*' -mtime +30 -delete"
+    user: root
+
+# Remove manually-added cron.d file (now managed by Ansible)
+- name: Remove manual cleanup-apache-logs cron.d file
+  become: yes
+  ansible.builtin.file:
+    path: /etc/cron.d/cleanup-apache-logs
+    state: absent

--- a/roles/regluit_prod/tasks/log_management.yml
+++ b/roles/regluit_prod/tasks/log_management.yml
@@ -1,0 +1,34 @@
+---
+# Log management: journal size cap and HTTP redirect log suppression
+# See: https://github.com/Gluejar/regluit/issues/1111
+# See: https://github.com/EbookFoundation/regluit-provisioning/issues/17
+
+# Cap systemd journal size — default is unbounded and can consume 1.5GB+
+- name: Create journald config directory
+  become: yes
+  ansible.builtin.file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    mode: 0755
+
+- name: Cap systemd journal size to 500MB
+  become: yes
+  ansible.builtin.copy:
+    content: |
+      [Journal]
+      SystemMaxUse=500M
+    dest: /etc/systemd/journald.conf.d/size-limit.conf
+    mode: 0644
+  notify: restart journald
+
+# The port 80 vhost only does HTTP→HTTPS redirects.
+# Without a CustomLog, Apache falls back to other_vhosts_access.log
+# which grows unbounded (was 933MB at one point). Disable it.
+- name: Disable other-vhosts-access-log (redirect log noise)
+  become: yes
+  ansible.builtin.command:
+    cmd: a2disconf other-vhosts-access-log
+  register: a2disconf_result
+  changed_when: "'Conf other-vhosts-access-log disabled' in a2disconf_result.stdout"
+  failed_when: false
+  notify: restart apache

--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -130,8 +130,7 @@
 - name: Run cron tasks
   import_tasks: cron.yml
 
-
-
-
+- name: Run log management tasks
+  import_tasks: log_management.yml
 
 


### PR DESCRIPTION
## Summary

- Production hit **97% disk** (525MB free on 16GB) on 2026-03-12 due to unmanaged log growth
- Apache access logs: 7.7GB (single days hitting 1.1GB under bot traffic)
- Celery w1.log: 443MB (never rotated)
- systemd journal: 1.6GB (no size cap)
- Emergency cleanup freed 5.8GB, but we need Ansible to prevent recurrence

## Changes

### `cron.yml` — tightened and expanded
- Apache uncompressed logs: delete after **7 days** (was 14)
- Apache compressed logs: delete after **14 days** (was: never — `.gz` files were missed entirely)
- **New**: Compress apache logs older than 2 days (saves ~80% space)
- **New**: Truncate celery `w1.log` weekly (keep last 5000 lines)
- **New**: Clean old celery metrics HTML after 30 days
- **New**: Clean old regluit app logs after 30 days
- **New**: Remove manually-added `/etc/cron.d/cleanup-apache-logs` (now Ansible-managed)

### `log_management.yml` — new task file
- Cap systemd journal at 500MB (was unbounded)
- Disable `other_vhosts_access.log` — the port 80 vhost only does HTTP→HTTPS redirects; this log has zero diagnostic value and was the subject of #17

### `handlers/main.yml`
- Add `restart journald` handler

## Log lifecycle after this PR

```
Day 0-2:  raw .log files (live, written by cronolog)
Day 2-7:  compressed .log.gz files  
Day 7:    uncompressed files deleted
Day 14:   compressed files deleted
```

## Test plan

- [ ] Verify cron jobs appear in `sudo crontab -l` after provisioning
- [ ] Verify `other_vhosts_access.log` stops growing after `a2disconf`
- [ ] Verify journal stays under 500MB (`journalctl --disk-usage`)
- [ ] Monitor disk usage over 1 week to confirm stability

Fixes: Gluejar/regluit#1111
Refs: #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)