### PR TITLE
security: pre-commit hook rejecting unencrypted private keys

### DIFF
--- a/.githooks/check-no-plaintext-keys.sh
+++ b/.githooks/check-no-plaintext-keys.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# check-no-plaintext-keys.sh
+#
+# Pre-commit hook that rejects files containing PEM private keys unless
+# the file is ansible-vault encrypted.
+#
+# Called by .pre-commit-config.yaml. Receives file paths as arguments.
+#
+# Why this exists: security-private#10 (April 2026). A Claude Code session
+# committed an unencrypted wildcard TLS private key to this public repo,
+# breaking the established convention of ansible-vault encrypting all keys
+# in private/. This hook is one of several layered controls to prevent
+# recurrence. The strongest control (GitHub Secret Scanning with Push
+# Protection) catches pushes server-side; this hook catches locally before
+# you even try to push.
+
+set -euo pipefail
+
+EXIT_CODE=0
+
+for file in "$@"; do
+    # Skip files that don't exist (deletions)
+    [ -f "$file" ] || continue
+
+    # Read first line
+    first_line=$(head -n 1 "$file" 2>/dev/null || echo "")
+
+    # Files prefixed with $ANSIBLE_VAULT are encrypted — allowed
+    case "$first_line" in
+        '$ANSIBLE_VAULT'*)
+            continue
+            ;;
+    esac
+
+    # Check for PEM private key markers anywhere in the file.
+    # Matches RSA, EC, DSA, OPENSSH, ENCRYPTED, etc.
+    if grep -qE -- '-----BEGIN ([A-Z]+ )?PRIVATE KEY-----' "$file"; then
+        echo "ERROR: $file contains a PEM private key but is not ansible-vault encrypted." >&2
+        echo "       First line: $first_line" >&2
+        echo "" >&2
+        echo "  To fix:" >&2
+        echo "    ansible-vault encrypt \"$file\"" >&2
+        echo "" >&2
+        echo "  To bypass (strongly discouraged; requires justification):" >&2
+        echo "    git commit --no-verify" >&2
+        echo "" >&2
+        echo "  See: EbookFoundation/security-private#10" >&2
+        EXIT_CODE=1
+    fi
+done
+
+exit $EXIT_CODE

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,7 +12,8 @@ name: Secret scan (gitleaks)
 #   The official Action started requiring a paid GITLEAKS_LICENSE for
 #   GitHub organizations (regardless of public/private repo status).
 #   The gitleaks binary itself remains MIT-licensed and free, so we
-#   run it directly.
+#   download the published release tarball and verify its SHA-256
+#   against a pinned value before execution.
 
 on:
   pull_request:
@@ -31,13 +32,23 @@ jobs:
           # base and head on PRs.
           fetch-depth: 0
 
-      - name: Install gitleaks
+      - name: Install gitleaks (verified download)
         env:
           GITLEAKS_VERSION: "8.30.1"
+          # Pinned SHA-256 for gitleaks_<version>_linux_x64.tar.gz from the
+          # official release. If this hash changes, the release has been
+          # retagged or replaced, and the workflow will fail-safe. Bump
+          # GITLEAKS_VERSION and this hash together after manual review.
+          # Source: https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_checksums.txt
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
         run: |
           set -euo pipefail
           curl -fsSL -o gitleaks.tar.gz \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+
+          # Verify integrity BEFORE extracting or executing anything.
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum --check --strict
+
           tar -xzf gitleaks.tar.gz gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
           gitleaks version

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,33 @@
+name: Secret scan (gitleaks)
+
+# Runs gitleaks against every PR and every push to master.
+# Catches secrets that slip past the pre-commit hook (e.g., when a
+# contributor hasn't installed pre-commit, or uses --no-verify).
+#
+# Added as part of EbookFoundation/security-private#10 remediation.
+# See also: .gitleaks.toml (allowlist config), .pre-commit-config.yaml
+# (local enforcement).
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code (with full history for delta scan)
+        uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 tells gitleaks-action to scan the full diff
+          # between base and head for PRs, and full history on push.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Public repo: no GITLEAKS_LICENSE required.
+          # Uses .gitleaks.toml from repo root for allowlist config.

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,6 +7,12 @@ name: Secret scan (gitleaks)
 # Added as part of EbookFoundation/security-private#10 remediation.
 # See also: .gitleaks.toml (allowlist config), .pre-commit-config.yaml
 # (local enforcement).
+#
+# Why not gitleaks/gitleaks-action@v2:
+#   The official Action started requiring a paid GITLEAKS_LICENSE for
+#   GitHub organizations (regardless of public/private repo status).
+#   The gitleaks binary itself remains MIT-licensed and free, so we
+#   run it directly.
 
 on:
   pull_request:
@@ -21,13 +27,36 @@ jobs:
       - name: Checkout code (with full history for delta scan)
         uses: actions/checkout@v4
         with:
-          # fetch-depth: 0 tells gitleaks-action to scan the full diff
-          # between base and head for PRs, and full history on push.
+          # fetch-depth: 0 so gitleaks can scan the full diff between
+          # base and head on PRs.
           fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Public repo: no GITLEAKS_LICENSE required.
-          # Uses .gitleaks.toml from repo root for allowlist config.
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # PR: scan the diff between base and head
+            gitleaks detect \
+              --source . \
+              --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" \
+              --verbose \
+              --redact
+          else
+            # Push: scan the commits in this push
+            gitleaks detect \
+              --source . \
+              --log-opts "${{ github.event.before }}..${{ github.sha }}" \
+              --verbose \
+              --redact
+          fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,33 @@
+# gitleaks configuration for regluit-provisioning
+#
+# See: https://github.com/gitleaks/gitleaks#configuration
+#
+# Why this file exists: gitleaks' default ruleset catches generic API keys
+# and private key headers — both useful. But Ansible template defaults in
+# this repo intentionally contain placeholder values (like "0123456789...")
+# that trigger false positives. Those templates render at deploy time from
+# real secrets stored in vault.yml files (ansible-vault encrypted).
+#
+# Added as part of EbookFoundation/security-private#10 remediation.
+
+title = "regluit-provisioning gitleaks config"
+
+# Use gitleaks' default rules as the base. Our additions below only ADD
+# allowlist entries; they do not weaken detection.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Placeholder values in role defaults and templates — real secrets come from vault.yml files"
+paths = [
+    # Ansible role defaults — values overridden by vault.yml at deploy time.
+    # These files contain placeholder strings like "012345678901234" and
+    # "abcdef1234567890abcdef1234567890" that are meant to be replaced.
+    '''roles/regluit_common/defaults/main\.yml$''',
+
+    # Jinja2 templates — same pattern: placeholder default values in
+    # os.environ.get() calls, meant to be overridden by real env vars or
+    # vault-rendered config at deploy time.
+    '''roles/regluit_common/templates/common\.py\.j2$''',
+    '''roles/regluit_common/templates/host\.py\.j2$''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,30 +4,43 @@
 #
 # Why this file exists: gitleaks' default ruleset catches generic API keys
 # and private key headers — both useful. But Ansible template defaults in
-# this repo intentionally contain placeholder values (like "0123456789...")
-# that trigger false positives. Those templates render at deploy time from
-# real secrets stored in vault.yml files (ansible-vault encrypted).
+# this repo intentionally contain placeholder values (like "012345678901234"
+# and "abcdef1234567890abcdef1234567890") that trigger false positives.
+# Those placeholders are overridden at deploy time by real values from
+# vault.yml files (ansible-vault encrypted).
 #
 # Added as part of EbookFoundation/security-private#10 remediation.
+#
+# IMPORTANT: this config allowlists by placeholder *content*, NOT by file
+# path. A prior version allowlisted entire template files, which would
+# have silently hidden any real secret later committed to those files.
+# This version scopes suppression to the specific placeholder strings.
 
 title = "regluit-provisioning gitleaks config"
 
-# Use gitleaks' default rules as the base. Our additions below only ADD
+# Use gitleaks' default rules as the base. Additions below only ADD
 # allowlist entries; they do not weaken detection.
 [extend]
 useDefault = true
 
 [allowlist]
-description = "Placeholder values in role defaults and templates — real secrets come from vault.yml files"
-paths = [
-    # Ansible role defaults — values overridden by vault.yml at deploy time.
-    # These files contain placeholder strings like "012345678901234" and
-    # "abcdef1234567890abcdef1234567890" that are meant to be replaced.
-    '''roles/regluit_common/defaults/main\.yml$''',
+description = "Obvious placeholder strings used in Ansible template defaults — real secrets come from vault.yml"
 
-    # Jinja2 templates — same pattern: placeholder default values in
-    # os.environ.get() calls, meant to be overridden by real env vars or
-    # vault-rendered config at deploy time.
-    '''roles/regluit_common/templates/common\.py\.j2$''',
-    '''roles/regluit_common/templates/host\.py\.j2$''',
+# Stopwords: if the detected secret value CONTAINS any of these substrings,
+# the finding is filtered. Stopwords are checked against the matched secret
+# itself, not the surrounding file content, so a real secret appearing
+# elsewhere in the same file will still be flagged.
+stopwords = [
+    # Sequential-digit placeholders used across defaults/main.yml and
+    # *.j2 templates (dropbox_key, boxstream_api_key, MOBIGEN_PASSWORD,
+    # SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET default, AWS_ACCESS_KEY_ID default, etc.)
+    "012345678901234",
+
+    # Hex placeholder used for LIBRARYTHING_KEY default
+    "abcdef1234567890",
+
+    # Cloudflare Turnstile test/dummy key documented at
+    # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+    # (always fails validation; safe to ship as a default)
+    "1x0000000000000000000000000000000AA",
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,12 @@ repos:
       - id: check-merge-conflict
       - id: trailing-whitespace
         exclude: '\.(crt|csr|key|pem|ca-bundle)$'
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        # Broader secret scanning: AWS keys, GitHub tokens, Stripe keys,
+        # generic API keys, private keys in any PEM format, etc. Uses
+        # .gitleaks.toml for repo-specific allowlists (placeholder defaults
+        # in templates are allowlisted there).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+# Pre-commit hooks for regluit-provisioning
+#
+# Install: pip install pre-commit && pre-commit install
+# Manual run: pre-commit run --all-files
+#
+# These hooks run on every `git commit` to catch security and hygiene issues
+# before they become commits. They can be bypassed with --no-verify but that's
+# intentional — commit with care.
+
+repos:
+  - repo: local
+    hooks:
+      - id: no-plaintext-private-keys
+        name: Reject unencrypted private keys
+        description: |
+          Refuse to commit files containing PEM private keys unless the file
+          is ansible-vault encrypted (starts with $ANSIBLE_VAULT). This
+          prevents accidents like security-private#10 where a wildcard key
+          was committed to a public repo.
+        entry: .githooks/check-no-plaintext-keys.sh
+        language: script
+        pass_filenames: true
+        types: [file]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+        # Built-in hook as a belt-and-suspenders check; catches common PEM
+        # headers (RSA, EC, PGP, etc.) that our custom hook might miss.
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+        exclude: '\.(crt|csr|key|pem|ca-bundle)$'


### PR DESCRIPTION
Part of the remediation for [EbookFoundation/security-private#10](https://github.com/EbookFoundation/security-private/issues/10) — the April 8 wildcard TLS private key exposure.

## Why

A Claude Code session on April 8 committed an unencrypted wildcard `*.unglue.it` + `unglue.it` private key to this public repo. The key was exposed for ~13 days before detection. See [security-private#10](https://github.com/EbookFoundation/security-private/issues/10) for the full incident report, forensics, and post-mortem.

The compromised cert has been revoked (LE accepted `keyCompromise`) and the plaintext key removed from the working tree. This PR adds **layered prevention** so the same class of leak is caught locally and in CI going forward.

## What changed

### Local layer — pre-commit hooks

- **`.pre-commit-config.yaml`** — pre-commit framework config with three hooks:
  - `no-plaintext-private-keys` — custom hook rejecting PEM private keys unless file is `$ANSIBLE_VAULT`-prefixed
  - `pre-commit-hooks/detect-private-key` — built-in redundant check
  - **`gitleaks/gitleaks`** — broader scanning (AWS keys, GitHub tokens, Stripe keys, generic API keys, private keys in any PEM format, etc.)

- **`.githooks/check-no-plaintext-keys.sh`** — the custom hook logic. Scans each staged file for PEM private key headers (RSA, EC, DSA, OPENSSH, ENCRYPTED). Rejects if found and file is not ansible-vault encrypted.

- **`.gitleaks.toml`** — repo-specific gitleaks config. Extends the default ruleset with an allowlist for three files containing Ansible template placeholder defaults (`012345678901234...` and `abcdef...` patterns meant to be overridden by `vault.yml` at deploy time). Without this allowlist, gitleaks produces known false positives.

### CI layer — GitHub Actions

- **`.github/workflows/gitleaks.yml`** — runs gitleaks on every PR and every push to master. Downloads the gitleaks binary directly (MIT-licensed) rather than using the official `gitleaks-action@v2` (which now requires a paid license for GitHub organizations). Catches secrets that slip past the pre-commit hook when a contributor hasn't installed it or uses `--no-verify`.

## Why the belt-and-suspenders approach

GitHub's built-in Secret Scanning + Push Protection was enabled on this repo today as part of the incident response. Empirical testing on 2026-04-21 revealed it **does NOT reliably block generic PEM private keys** (our specific threat model). The free tier validates vendor tokens (real AWS keys, real GitHub PATs) with the issuer; generic PEM detection requires paid GitHub Advanced Security. See the [correction comment on security-private#10](https://github.com/EbookFoundation/security-private/issues/10#issuecomment-4292242308).

gitleaks uses pure pattern matching (no issuer validation) so it catches generic keys reliably. This PR closes that coverage gap.

## Verified

| Test | Expected | Actual |
|------|----------|--------|
| Custom hook: plaintext PEM key file | REJECT | ✅ REJECT |
| Custom hook: `$ANSIBLE_VAULT` file | ALLOW | ✅ ALLOW |
| Custom hook: all 10 existing vault-encrypted keys | all PASS | ✅ all PASS |
| gitleaks on current tree | 0 leaks (allowlist filters placeholders) | ✅ 0 leaks |
| gitleaks on full git history | 1 leak (the d474401 April 8 commit itself, now revoked) | ✅ 1 leak (expected historical) |
| gitleaks on fresh synthetic RSA key | DETECT | ✅ DETECT |
| CI workflow on this branch | success | ✅ success |

## Layered controls stack after this PR merges

| Layer | Where | Bypassable? | Catches generic PEM? | Catches vendor tokens? |
|-------|-------|-------------|---------------------|------------------------|
| Pre-commit hook (custom) | Local | `--no-verify` | ✅ | ❌ (by design) |
| Pre-commit hook (gitleaks) | Local | `--no-verify` | ✅ | ✅ |
| GitHub Push Protection | Server | Org bypass only | ❌ (needs paid GHAS) | ✅ |
| GitHub Actions gitleaks | Server | No | ✅ | ✅ |

No single layer is sufficient. Together: defense in depth.

## Contributor setup

After this PR merges, collaborators should install the pre-commit hook once:

```
pip install pre-commit
pre-commit install
```

Then `git commit` runs all three hooks automatically. Bypass with `--no-verify` for exceptional cases (discouraged — CI will still catch you).

## Test plan

- [x] Custom hook rejects fake plaintext keys; allows vault-encrypted files
- [x] gitleaks scans run cleanly on current tree (allowlist working)
- [x] gitleaks catches synthetic new keys
- [x] CI workflow runs successfully on branch push
- [ ] After merge, mark "Secret scan (gitleaks)" as a required status check in branch protection

## Not in this PR

Tracked in [security-private#10](https://github.com/EbookFoundation/security-private/issues/10):

- Fix `roles/regluit_prod/tasks/certs.yml:138` to use decrypted-at-runtime path
- Remove `force: yes` from `acme_certificate` task
- ADR documenting per-host certs as default pattern
- Collaborator list pruning (33 push-access accounts)
- Branch protection rules on master