### PR TITLE
Per-env ADMINS override: stop staging errors from paging prod admins

### DIFF
--- a/group_vars/dev/vars.yml
+++ b/group_vars/dev/vars.yml
@@ -17,6 +17,10 @@ le_endpoint: https://acme-v02.api.letsencrypt.org/directory
 alt_server_name: ""
 deploy_type: 'dev' # change to 'test' to activate send_test_email
 
+# Non-production environment: suppress error emails to prod admins.
+# See EbookFoundation/security-private#11.
+disable_admin_emails: true
+
 
 
 ### Variables in settings.prod.py ###

--- a/roles/regluit_prod/templates/prod.py.j2
+++ b/roles/regluit_prod/templates/prod.py.j2
@@ -9,10 +9,17 @@ IS_PREVIEW = False
 
 SITE_ID = 1
 
+{% if disable_admin_emails | default(false) %}
+# This environment is non-production; override ADMINS to an empty tuple so
+# Django's AdminEmailHandler doesn't forward staging errors to production
+# admins. See EbookFoundation/security-private#11 (2026-04-23 incident).
+ADMINS = ()
+{% else %}
 ADMINS = (
-    ('Raymond Yee', 'rdhyee+ungluebugs@gluejar.com'),
+    ('Raymond Yee', 'raymond.yee+ungluebugs@gmail.com'),
     ('Eric Hellman', 'eric@gluejar.com'),
 )
+{% endif %}
 
 MANAGERS = ADMINS
 


### PR DESCRIPTION
Refs [EbookFoundation/security-private#11](https://github.com/EbookFoundation/security-private/issues/11) and [Gluejar/regluit#1127](https://github.com/Gluejar/regluit/issues/1127).

## Why

On 2026-04-23, a template-not-found bug on `test.unglue.it` produced **7,700+ admin error emails in a single day**. Two compounding amplification vectors:

1. Django's `AdminEmailHandler` has no built-in rate limit → bots hitting a broken view = one email per request.
2. `ADMINS` was shared between production and non-production environments → a broken staging view fired emails to the same addresses monitoring production.

Vector (1) is addressed by the companion PR [`Gluejar/regluit#1128`](https://github.com/Gluejar/regluit/pull/1128). This PR addresses vector (2) on the provisioning side.

## What

**`roles/regluit_prod/templates/prod.py.j2`**: wrap the `ADMINS` tuple in a Jinja2 conditional:

```jinja
{% if disable_admin_emails | default(false) %}
ADMINS = ()
{% else %}
ADMINS = (
    ('Raymond Yee', 'raymond.yee+ungluebugs@gmail.com'),
    ('Eric Hellman', 'eric@gluejar.com'),
)
{% endif %}
```

When the group_var is truthy, render empty `ADMINS` — `AdminEmailHandler` sees no recipients and silently drops the email. When the flag is falsy (the default, and what production will use), render the usual tuple.

Also updates the stale `rdhyee+ungluebugs@gluejar.com` address to `raymond.yee+ungluebugs@gmail.com` (same change as in the companion regluit PR's `settings/dev.py`).

**`group_vars/dev/vars.yml`**: set `disable_admin_emails: true`. `dev` (m.unglue.it) is non-production and should not page prod admins.

## Interaction with [regluit-provisioning#25](https://github.com/EbookFoundation/regluit-provisioning/pull/25)

This PR is **branched from master** and does NOT modify the `test` or `dj42` group_vars — those files are added/modified by PR #25. Once PR #25 merges, a small follow-up PR should add `disable_admin_emails: true` to:
- `group_vars/test/vars.yml`
- `group_vars/dj42/vars.yml`

In the meantime, `test.unglue.it` and `dj42.unglue.it` continue to rely on the companion regluit PR's rate-limit filter to throttle any flood (still an ~80% mitigation). The Jinja2 conditional in this PR is in place and ready for when those group_vars arrive.

## Verified

- Jinja2 syntax parses correctly
- `disable_admin_emails` defaults to `false` for any environment that doesn't set it (production path is preserved)

## Test plan

- [ ] Deploy this branch to `m.unglue.it` (or any env with `disable_admin_emails: true`) and confirm rendered `prod.py` contains `ADMINS = ()`
- [ ] Deploy to production and confirm rendered `prod.py` contains the full ADMINS tuple with the updated Raymond address

## Scope deferred

- Adding `disable_admin_emails: true` to test and dj42 group_vars (blocked on PR #25 landing)
- Sentry or equivalent structured error aggregation (separate evaluation)