### PR TITLE
Remove dead test branch in prod.py.j2 (SEND_TEST_EMAIL_JOB / SAVE_INFO_PAGE_TEST refs)

### DIFF
--- a/roles/regluit_prod/templates/prod.py.j2
+++ b/roles/regluit_prod/templates/prod.py.j2
@@ -119,10 +119,7 @@ CELERYBEAT_SCHEDULE = {}
 CELERY_LOG_DIR = '/var/log/celery'
 
 # decide which of the period tasks to add to the schedule
-if '{{ deploy_type }}' == 'test':
-    CELERYBEAT_SCHEDULE['send_test_email'] = SEND_TEST_EMAIL_JOB
-    CELERYBEAT_SCHEDULE['save_info_page'] = SAVE_INFO_PAGE_TEST
-elif '{{ deploy_type }}' == 'prod':
+if '{{ deploy_type }}' == 'prod':
     # update the statuses of campaigns
     CELERYBEAT_SCHEDULE['update_active_campaign_statuses'] = UPDATE_ACTIVE_CAMPAIGN_STATUSES
     CELERYBEAT_SCHEDULE['report_new_ebooks'] = EBOOK_NOTIFICATIONS_JOB


### PR DESCRIPTION
Companion PR to [Gluejar/regluit#1132](https://github.com/Gluejar/regluit/pull/1132) — closes part of [Gluejar/regluit#1131](https://github.com/Gluejar/regluit/issues/1131).

## Why

The `if '{{ deploy_type }}' == 'test':` branch in `roles/regluit_prod/templates/prod.py.j2` registered two scheduled Celery tasks that no longer serve a purpose:

| Symbol | Status in regluit codebase | Effect |
|---|---|---|
| `SEND_TEST_EMAIL_JOB` | Defined in `settings/common.py`; being removed in [Gluejar/regluit#1132](https://github.com/Gluejar/regluit/pull/1132) | Mailed `"hi there 20,25,30"` to Eric 72 times/day on any host tagged `deploy_type=test`. 1,796 dispatches documented on test.unglue.it through 2026-02-24. |
| `SAVE_INFO_PAGE_TEST` | **Not defined anywhere** | Django startup would `NameError` if this branch ever matched. The test branch has been broken at runtime for a long time. |

## What this PR changes

```diff
 # decide which of the period tasks to add to the schedule
-if '{{ deploy_type }}' == 'test':
-    CELERYBEAT_SCHEDULE['send_test_email'] = SEND_TEST_EMAIL_JOB
-    CELERYBEAT_SCHEDULE['save_info_page'] = SAVE_INFO_PAGE_TEST
-elif '{{ deploy_type }}' == 'prod':
+if '{{ deploy_type }}' == 'prod':
     # update the statuses of campaigns
     CELERYBEAT_SCHEDULE['update_active_campaign_statuses'] = UPDATE_ACTIVE_CAMPAIGN_STATUSES
     ...
```

One file, 4 deletions + 1 insertion.

## Merge order

Either order is safe:
- **This PR first**: template no longer references the removed symbol → `regluit#1132` becomes a pure cleanup with no template coupling
- **`regluit#1132` first**: template's test branch becomes technically broken (references undefined `SEND_TEST_EMAIL_JOB`), but the branch was **already broken** due to the undefined `SAVE_INFO_PAGE_TEST`, so the break is net-neutral — `deploy_type=test` never worked, and continues to not work during the brief window between the two merges.

## Deploy

Next Ansible run picks up the new template. Production deploy regenerates `prod.py` with the same tasks registered; no behavior change for `deploy_type=prod` hosts. Test hosts (`deploy_type` currently rendered as `dev` on test.unglue.it) already have an empty `CELERYBEAT_SCHEDULE`, so no behavior change there either.

## Secondary findings (out of scope — file separately)

1. **test.unglue.it `deploy_type=dev` mismatch**: rendered conditional says `'dev' == 'test'` / `'dev' == 'prod'` — neither matches. Worth reworking to boolean group_vars (e.g., `register_production_tasks: true/false`) rather than string-equality.
2. **celerybeat `failed` on test.unglue.it**: separate systemd/celery issue; needs its own ticket.

## Test plan

- [x] Jinja renders correctly for `deploy_type=prod` (same output as before minus the dead branch)
- [x] Jinja renders correctly for `deploy_type=dev` and `deploy_type=test` (both now leave `CELERYBEAT_SCHEDULE = {}` empty — unchanged from current behavior)
- [ ] After deploy to prod: `grep SEND_TEST_EMAIL_JOB /opt/regluit/regluit/settings/prod.py` on prod → zero hits
- [ ] After deploy to prod: all currently-scheduled tasks continue firing (check celery worker log for daily ticks: `update_active_campaign_status`, `emit_notifications`, `periodic_cleanup`, etc.)

## Related

- [Gluejar/regluit#1131](https://github.com/Gluejar/regluit/issues/1131) — tracking issue with full analysis
- [Gluejar/regluit#1132](https://github.com/Gluejar/regluit/pull/1132) — companion PR on regluit
- [EbookFoundation/security-private#11](https://github.com/EbookFoundation/security-private/issues/11) — email-flood post-mortem (surfaced this cleanup during HiThere hunt)