### PR TITLE
Automate DOAB harvest on nightly cadence (Gluejar/regluit#1129)

### DIFF
--- a/roles/regluit_prod/tasks/cron.yml
+++ b/roles/regluit_prod/tasks/cron.yml
@@ -80,3 +80,22 @@
   ansible.builtin.file:
     path: /etc/cron.d/cleanup-apache-logs
     state: absent
+
+# DOAB OAI harvest — runs nightly on production only.
+# Matches doab-check's cadence (nightly load_doab) per Gluejar/regluit#1129
+# and Eric's direction (2026-04-23 meeting).
+#
+# Window: 3 days back -> open-ended. The 3-day overlap is intentional —
+# load_doab dedupes by record id, so re-fetching is cheap and resilient
+# to occasional missed nights (server reboot, transient OAI 5xx, etc.).
+# Output (incl. stderr) appended to /var/log/regluit/doab-harvest.log,
+# which is rotated by the existing "regluit-log-cleanup" task above.
+- name: DOAB harvest (nightly)
+  become: yes
+  ansible.builtin.cron:
+    name: "regluit-doab-harvest"
+    minute: "30"
+    hour: "4"
+    user: "{{ user_name }}"
+    job: 'cd {{ project_path }} && DJANGO_SETTINGS_MODULE={{ django_settings_module }} {{ project_path }}/{{ virtualenv_name }}/bin/django-admin load_doab "$(date -u -d ''3 days ago'' +\%Y-\%m-\%d)" --max=20000 >> /var/log/regluit/doab-harvest.log 2>&1'
+  when: deploy_type | default('') == 'prod'


### PR DESCRIPTION
Closes Gluejar/regluit#1129.

## Summary

Adds a nightly cron task on production to invoke `django-admin load_doab` with a 3-day rolling window. Matches the nightly cadence used by [EbookFoundation/doab-check](https://github.com/EbookFoundation/doab-check) (its `scripts/doab_load.sh` is also nightly per [doab-check#11](https://github.com/EbookFoundation/doab-check/issues/11) — "**nightly** harvest cron failing silently"), per Eric's direction in the 2026-04-23 meeting.

Replaces the prior manual ~2-week-cadence pattern (visible in `/home/ubuntu/load_doab.txt` on prod). Last manual catch-up was 2026-04-23, which closed a 10-week gap that had built up after the last logged manual run on 2026-02-17.

## Design choices

| Choice | Reasoning |
|---|---|
| **04:30 UTC** | After the existing 03:00–03:25 UTC log-cleanup tasks; comfortably ahead of US/EU peak traffic. |
| **3-day rolling window** | `load_doab` dedupes by record id, so re-fetching is idempotent. Tolerates occasional missed nights (server reboot, transient OAI 5xx) without manual catch-up. Empirical: typical day's harvest is well under 1000 records, so 3-day windows are far below the `--max=20000` cap. |
| **`when: deploy_type == 'prod'`** | Skips on dev/test/dj42. Staging environments should not be hitting DOAB OAI on cron, and on dj42 specifically the schema may diverge during the Django 4.2 migration (PR Gluejar/regluit#1123). |
| **Log to `/var/log/regluit/doab-harvest.log`** | Rotated by the existing `regluit-log-cleanup` task (30-day retention). The `starting at date:...` / `loaded N records (M new), ending at...` lines emitted by `load_doab` itself serve as natural per-run delimiters. |
| **Cron `ubuntu` user** | Matches who runs the manual invocations today. The venv at `{{ project_path }}/{{ virtualenv_name }}/bin/django-admin` is owned by ubuntu; running as root would create permission issues with output files. |
| **Stdout + stderr both go to log** | Failure visibility is via the log content, not via cron-mail. Trade-off: transient OAI 503s won't email admins, but also won't email-spam them. The existing AdminEmailHandler rate-limit work (Gluejar/regluit#1128) is the right place for failure notification, separate from this PR. |

## Test plan

- [ ] Run `ansible-playbook -i hosts setup-prod.yml` — confirm new task lands and creates the cron entry under `ubuntu`'s crontab
- [ ] `sudo -u ubuntu crontab -l | grep doab` — verify the entry exists, in correct format
- [ ] Wait one cycle (or `sudo -u ubuntu /the/full/job-line`) and verify `/var/log/regluit/doab-harvest.log` gets a normal `starting at date:... loaded N records...` entry
- [ ] Run against test/dj42 envs (post-merge of #25 once it's there): confirm task is **skipped** by the `deploy_type == 'prod'` guard

## Out of scope (deliberately)

- **Failure notification**: cron currently logs to file only. Adding mail-on-error or a separate health-check is left for a follow-up, after Gluejar/regluit#1128 (AdminEmailHandler rate-limiting) lands and we can wire up notification without spam risk.
- **Switch to Celery Beat**: Option A in the issue body. Cron is simpler and matches doab-check's choice; revisit if/when load_doab's scheduling needs grow.
- **Backfill the `~/load_doab.txt` log style**: existing manual log file (`/home/ubuntu/load_doab.txt`) keeps being written by manual runs. The new cron writes to `/var/log/regluit/doab-harvest.log`. They co-exist cleanly; consolidating is a future cleanup.

## Notes

This PR is small and isolated (1 file, 19 insertions). Merging it into master is independent of regluit-provisioning#25 — they touch different files, no conflicts expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)