### PR TITLE
Orchestrate DOAB backfill drain + serialise harvest under shared flock

### DIFF
--- a/roles/regluit_prod/tasks/cron.yml
+++ b/roles/regluit_prod/tasks/cron.yml
@@ -81,21 +81,7 @@
     path: /etc/cron.d/cleanup-apache-logs
     state: absent
 
-# DOAB OAI harvest — runs nightly on production only.
-# Matches doab-check's cadence (nightly load_doab) per Gluejar/regluit#1129
-# and Eric's direction (2026-04-23 meeting).
-#
-# Window: 3 days back -> open-ended. The 3-day overlap is intentional —
-# load_doab dedupes by record id, so re-fetching is cheap and resilient
-# to occasional missed nights (server reboot, transient OAI 5xx, etc.).
-# Output (incl. stderr) appended to /var/log/regluit/doab-harvest.log,
-# which is rotated by the existing "regluit-log-cleanup" task above.
-- name: DOAB harvest (nightly)
-  become: yes
-  ansible.builtin.cron:
-    name: "regluit-doab-harvest"
-    minute: "30"
-    hour: "4"
-    user: "{{ user_name }}"
-    job: 'cd {{ project_path }} && DJANGO_SETTINGS_MODULE={{ django_settings_module }} {{ project_path }}/{{ virtualenv_name }}/bin/django-admin load_doab "$(date -u -d ''3 days ago'' +\%Y-\%m-\%d)" --max=20000 >> /var/log/regluit/doab-harvest.log 2>&1'
-  when: deploy_type | default('') == 'prod'
+# DOAB OAI harvest + backfill cron, the wrapper scripts that install them,
+# and the shared flock that serialises them are all owned by doab.yml
+# (imported from main.yml). Kept together because the nightly harvest and
+# the one-off backfill must share a single host lock — see doab.yml.

--- a/roles/regluit_prod/tasks/doab.yml
+++ b/roles/regluit_prod/tasks/doab.yml
@@ -1,0 +1,76 @@
+---
+# DOAB OAI orchestration — nightly harvest + one-off backfill.
+#
+# Both hit the same DOAB OAI endpoint. They must NEVER run concurrently
+# (slow-and-gentle: never double the request rate). Coordination is a single
+# host lock /var/lock/doab-oai.lock, acquired non-blocking (flock -n) inside
+# BOTH wrapper scripts: whichever is running, the other skips its tick.
+#
+# - Harvest  (Gluejar/regluit#1129): nightly, 3-day rolling window.
+# - Backfill (Gluejar/regluit#1151): one-off ~20.6k catch-up, bounded per
+#   tick, resumable, halt-aware via .done/.halted markers. Drains over days.
+#
+# Production only (deploy_type == 'prod').
+#
+# CROSS-HOST INVARIANT: this flock is host-local. doab-check (separate DO
+# host) also drains a DOAB backfill against the same OAI endpoint. Only ONE
+# may be armed at a time. regluit is the active runner (auto via discovery);
+# doab-check's runner is inert until its operator explicitly sets IDS_FILE.
+# Do not arm doab-check's backfill until this one's .done marker is present.
+
+- name: Create DOAB backfill state directory
+  become: yes
+  ansible.builtin.file:
+    path: /var/lib/regluit/doab-backfill
+    state: directory
+    owner: "{{ user_name }}"
+    group: "www-data"
+    mode: "02775"
+  when: deploy_type | default('') == 'prod'
+
+# /var/log/regluit is created in main.yml; doab-harvest.log /
+# doab-backfill.log land there and are rotated by the existing
+# "regluit-log-cleanup" task in cron.yml (30-day retention).
+
+- name: Install DOAB harvest wrapper script
+  become: yes
+  ansible.builtin.template:
+    src: doab-harvest.sh.j2
+    dest: "/home/{{ user_name }}/doab-harvest.sh"
+    owner: "{{ user_name }}"
+    mode: "0755"
+  when: deploy_type | default('') == 'prod'
+
+- name: Install DOAB backfill runner script
+  become: yes
+  ansible.builtin.template:
+    src: doab-backfill.sh.j2
+    dest: "/home/{{ user_name }}/doab-backfill.sh"
+    owner: "{{ user_name }}"
+    mode: "0755"
+  when: deploy_type | default('') == 'prod'
+
+- name: DOAB harvest (nightly, flock-serialised)
+  become: yes
+  ansible.builtin.cron:
+    name: "regluit-doab-harvest"
+    minute: "30"
+    hour: "4"
+    user: "{{ user_name }}"
+    job: "/home/{{ user_name }}/doab-harvest.sh"
+  when: deploy_type | default('') == 'prod'
+
+# Backfill ticks every 30 min, deliberately offset from the 04:30 harvest.
+# ~20.6k records / ~500 per pass ≈ 40+ ticks ≈ ~1 day at this cadence —
+# the intended slow drip. The flock guarantees a tick that overlaps the
+# nightly harvest simply skips (and vice-versa). Self-disables via the
+# .done marker once drained; freezes via .halted on a circuit-breaker.
+- name: DOAB backfill (bounded pass every 30 min, flock-serialised)
+  become: yes
+  ansible.builtin.cron:
+    name: "regluit-doab-backfill"
+    minute: "0,30"
+    hour: "*"
+    user: "{{ user_name }}"
+    job: "/home/{{ user_name }}/doab-backfill.sh"
+  when: deploy_type | default('') == 'prod'

--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -130,6 +130,9 @@
 - name: Run cron tasks
   import_tasks: cron.yml
 
+- name: Run DOAB orchestration tasks (harvest + backfill)
+  import_tasks: doab.yml
+
 - name: Run log management tasks
   import_tasks: log_management.yml
 

--- a/roles/regluit_prod/templates/doab-backfill.sh.j2
+++ b/roles/regluit_prod/templates/doab-backfill.sh.j2
@@ -1,0 +1,76 @@
+#!/bin/bash
+# DOAB backfill runner — one bounded pass per cron tick.
+#
+# Managed by Ansible (roles/regluit_prod/templates/doab-backfill.sh.j2).
+# Drains the ~20.6k-record DOAB catch-up worklist (Gluejar/regluit#1151) by
+# invoking `backfill_doab` repeatedly, slowly, never concurrently with the
+# nightly DOAB harvest (shared flock), honoring the in-command circuit
+# breakers ACROSS ticks via marker files.
+#
+# Exit-code contract (set by the management command):
+#   0  drained / nothing-to-do  -> write .done, stop running
+#   3  benign checkpoint        -> do nothing, cron re-fires next tick
+#   4  circuit-breaker halt      -> write .halted, freeze until operator clears
+#   *  unexpected                -> fail safe: write .halted
+#
+# NOTE: deliberately NOT `set -e` — we must inspect the command's rc.
+set -uo pipefail
+
+STATE_DIR=/var/lib/regluit/doab-backfill
+LOG=/var/log/regluit/doab-backfill.log
+LOCK=/var/lock/doab-oai.lock
+DONE="$STATE_DIR/.done"
+HALTED="$STATE_DIR/.halted"
+STATE="$STATE_DIR/state.json"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "$(ts) [doab-backfill] $*" >> "$LOG"; }
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+if [ -f "$DONE" ]; then
+    log ".done present — worklist drained; nothing to do"
+    exit 0
+fi
+if [ -f "$HALTED" ]; then
+    log ".halted present — circuit broken; awaiting operator review of $STATE"
+    exit 0
+fi
+
+# Single DOAB-OAI client per host: this lock is ALSO held by the nightly
+# harvest wrapper. -n => if held, skip this tick (cron fires again later).
+exec 9>"$LOCK" || { log "cannot open lock $LOCK; skipping tick"; exit 0; }
+if ! flock -n 9; then
+    log "DOAB-OAI lock held (harvest or prior backfill running); skipping tick"
+    exit 0
+fi
+
+log "starting bounded backfill pass"
+cd {{ project_path }} || { log "cd {{ project_path }} failed; skipping tick"; exit 0; }
+
+DJANGO_SETTINGS_MODULE={{ django_settings_module }} \
+    {{ project_path }}/{{ virtualenv_name }}/bin/django-admin backfill_doab \
+    --state-file "$STATE" >> "$LOG" 2>&1
+rc=$?
+
+case "$rc" in
+    0)
+        touch "$DONE"
+        log "DRAINED (rc=0) -> wrote .done; backfill complete"
+        ;;
+    3)
+        log "checkpoint (rc=3) -> cron will re-fire next tick"
+        ;;
+    4)
+        touch "$HALTED"
+        log "HALT (rc=4) -> wrote .halted; OPERATOR REVIEW NEEDED ($STATE)"
+        ;;
+    *)
+        touch "$HALTED"
+        log "UNEXPECTED rc=$rc -> wrote .halted (fail-safe); OPERATOR REVIEW NEEDED"
+        ;;
+esac
+
+# Never exit non-zero: a failing cron job mails root, and Eric treats
+# error-email volume as a signal. Failure is expressed via .halted + log.
+exit 0

--- a/roles/regluit_prod/templates/doab-harvest.sh.j2
+++ b/roles/regluit_prod/templates/doab-harvest.sh.j2
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Nightly DOAB OAI harvest (Gluejar/regluit#1129) — wrapped so it shares the
+# DOAB-OAI host lock with the backfill runner.
+#
+# Managed by Ansible (roles/regluit_prod/templates/doab-harvest.sh.j2).
+# Behaviour is unchanged from the original inline #31 cron except that it
+# now runs under `flock -n /var/lock/doab-oai.lock`, guaranteeing at most
+# one DOAB-OAI client process per host (slow-and-gentle: never double the
+# request rate by running harvest + backfill simultaneously).
+#
+# Window: 3 days back -> open-ended. load_doab dedupes by record id, so the
+# overlap is cheap and resilient to an occasional skipped night.
+#
+# Retry-After: this wrapper does NOT re-check the shared sentinel — the
+# `load_doab` management command reads it natively at the top of handle()
+# (read_block_deadline -> "SKIP: DOAB OAI rate-limited ..." -> return) using
+# the exact same race-free helpers as backfill. Keeping the wrapper thin
+# makes the command the single source of sentinel truth; duplicating the
+# check here would risk the two drifting.
+set -uo pipefail
+
+LOG=/var/log/regluit/doab-harvest.log
+LOCK=/var/lock/doab-oai.lock
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+exec 9>"$LOCK" || { echo "$(ts) [doab-harvest] cannot open lock $LOCK" >> "$LOG"; exit 0; }
+if ! flock -n 9; then
+    # Backfill (or a prior harvest) is using the OAI endpoint. Skip tonight;
+    # the 3-day rolling window self-heals the gap on the next clear night.
+    echo "$(ts) [doab-harvest] DOAB-OAI lock held; skipping this run" >> "$LOG"
+    exit 0
+fi
+
+cd {{ project_path }} || { echo "$(ts) [doab-harvest] cd failed" >> "$LOG"; exit 0; }
+FROM="$(date -u -d '3 days ago' +%Y-%m-%d)"
+echo "$(ts) [doab-harvest] starting load_doab from $FROM" >> "$LOG"
+DJANGO_SETTINGS_MODULE={{ django_settings_module }} \
+    {{ project_path }}/{{ virtualenv_name }}/bin/django-admin load_doab \
+    "$FROM" --max=20000 >> "$LOG" 2>&1
+echo "$(ts) [doab-harvest] load_doab exited rc=$?" >> "$LOG"
+exit 0


### PR DESCRIPTION
Companion to Gluejar/regluit#1152. Adds the production orchestration to actually drain the ~20.6k-record DOAB backfill and serialises it with the existing nightly harvest (#31, Gluejar/regluit#1129) under a shared host-local lock — so harvest + backfill can never hit DOAB OAI concurrently on this host. "Slow-and-gentle" enforced by code (flock) + halt-aware markers, not by hope.

## What's in this PR (1 commit, `83b1bf8`)

New artifacts under `roles/regluit_prod/`:

| Path | Role |
|---|---|
| `templates/doab-backfill.sh.j2` | One bounded `backfill_doab` pass per cron tick. Holds `/var/lock/doab-oai.lock` via `flock -n` for the whole pass. Honors the command's 0/3/4 exit codes via `.done` / `.halted` markers (the halt circuit-breaker is honored ACROSS ticks, not just within one run). Deliberately NOT `set -e` (must inspect rc); never exits non-zero (Eric treats cron mail as a signal — failure surfaces via `.halted` + log). |
| `templates/doab-harvest.sh.j2` | The existing nightly `load_doab` run, now wrapped in the same flock. Intentionally thin: `load_doab.handle()` reads the Retry-After sentinel natively (race-free per the regluit-side commits), so the wrapper does not duplicate that logic. |
| `tasks/doab.yml` | NEW. Owns all DOAB cron. Creates `/var/lib/regluit/doab-backfill` state dir, installs both scripts, schedules harvest (04:30) and backfill (every `:00`/`:30`). All `deploy_type == 'prod'`-gated. Documents the CROSS-HOST INVARIANT vs doab-check. |
| `tasks/cron.yml` | The inline #31 harvest cron entry is removed; ownership moves to `doab.yml` so harvest + backfill + their shared flock live together. A pointer comment is left. |
| `tasks/main.yml` | Imports `doab.yml` between `cron.yml` and `log_management.yml` so existing 30-day log rotation still covers the new `doab-*.log`. |

Cadence: ~20.6k / 500-per-pass ≈ 40+ ticks ≈ ~1 day at every-30-min — the intended slow drip. Self-disables via `.done` once drained; freezes via `.halted` on a circuit-breaker.

## Approval status

3 Codex code-review rounds, final: **LGTM**.

| Round | Outcome |
|---|---|
| R1 (plan) | 3 corrections: `set +e` rc-capture, skip paths must exit 3 not 0 (forced a command-side change tracked in Gluejar/regluit#1152), explicit dir/install Ansible tasks. All folded in. |
| R1 (code) | Verified clean: rc capture, exit mapping, `.done` only on rc 0, discovery-ban writes no `.done`, flock fd lifetime, `.halted` freeze. Two findings: harvest wrapper sentinel check, cross-host concurrency. |
| R2 | Finding-1 confirmed non-defect: `load_doab.handle()` reads the sentinel natively (proven inline). Finding-2 (cross-host) addressed by design (doab-check runner is disabled-by-default + invariant documented + minute-offset stagger). Caught new real defect: existing `doab-check/scripts/doab_load.sh` had no flock → harvest+backfill could collide on the doab-check host. |
| **R3** | **LGTM** — patched `doab_load.sh` in EbookFoundation/doab-check#19 closed the collision. |

### What deserves human eyes (not Codex's domain)

1. **Replacing the inline #31 harvest cron with a templated wrapper** — small behavioural delta (now skips a tick if the lock is held; the 3-day rolling window self-heals on the next clear night per the script's own pre-existing comments). This is the price of the slow-and-gentle invariant.

2. **The CROSS-HOST INVARIANT** is operator-managed (no distributed lock). regluit drains first (`.done`), then doab-check is armed by setting `IDS_FILE` in its crontab. Building a distributed lock between an AWS box and a DO droplet for a one-off catch-up would be over-engineering against the slow-and-gentle posture.

## Backlinks

- Gluejar/regluit#1151 — coverage gap audit (~20.6k missing)
- Gluejar/regluit#1152 — the regluit-side command + exit codes that this orchestrates
- EbookFoundation/doab-check#19 — parallel doab-check backfill + flocked harvest
- Original nightly harvest cron: #31 (`5ed52c1c`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context) — multi-round Codex CLI adversarial review
