### PR TITLE
Fix duplicate `refresh_acqs` key in prod Beat schedule

### DIFF
--- a/roles/regluit_prod/templates/prod.py.j2
+++ b/roles/regluit_prod/templates/prod.py.j2
@@ -134,7 +134,7 @@ if '{{ deploy_type }}' == 'prod':
     CELERYBEAT_SCHEDULE['update_account_statuses'] = UPDATE_ACCOUNT_STATUSES
     CELERYBEAT_SCHEDULE['notify_expiring_accounts'] = NOTIFY_EXPIRING_ACCOUNTS
     CELERYBEAT_SCHEDULE['refresh_acqs'] = REFRESH_ACQS_JOB
-    CELERYBEAT_SCHEDULE['refresh_acqs'] = NOTIFY_UNCLAIMED_GIFTS
+    CELERYBEAT_SCHEDULE['notify_unclaimed_gifts'] = NOTIFY_UNCLAIMED_GIFTS
     CELERYBEAT_SCHEDULE['save_info_page'] = SAVE_INFO_PAGE
     CELERYBEAT_SCHEDULE['periodic_cleanup'] = PERIODIC_CLEANUP
     CELERYBEAT_SCHEDULE['emit_notices'] = EMIT_NOTICES


### PR DESCRIPTION
Fixes #37.

## Why (first line)
The prod `CELERYBEAT_SCHEDULE` assigns the key `refresh_acqs` **twice** — the second line overwrote the first, so `refresh_acqs` was never scheduled and `notify_unclaimed_gifts` ran under the wrong key.

## Change
```diff
 CELERYBEAT_SCHEDULE['refresh_acqs'] = REFRESH_ACQS_JOB
-CELERYBEAT_SCHEDULE['refresh_acqs'] = NOTIFY_UNCLAIMED_GIFTS
+CELERYBEAT_SCHEDULE['notify_unclaimed_gifts'] = NOTIFY_UNCLAIMED_GIFTS
```

## ⚠️ Sequencing (why draft)
- This is on `master` (literal `CELERYBEAT_SCHEDULE`). **PR #25** refactors this same block to `{{ sched }}['...']` for the Celery 4/5 split. Whichever lands second must carry the corrected key — simplest is to **fold this one-liner into #25 before merge**, or rebase this after #25.
- **Behavior change:** this re-activates `refresh_acqs` (currently dead) and re-keys `notify_unclaimed_gifts` (an email-sending job). It should be **sequenced with the Celery Beat jobs review** for the Django 4.2 cutover (which of the 11 jobs fire on restart). Holding as draft until that decision lands.