### PR TITLE
apache: WSGIApplicationGroup %{GLOBAL} — fix stray [] in Django 4.2 form errors (Gluejar/regluit#1163)

### DIFF
--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -29,6 +29,14 @@ SSLCertificateChainFile /etc/ssl/certs/{{ server_name }}.ca-bundle
 
 WSGIDaemonProcess regluit processes=2 threads=15 python-eggs=/tmp/regluit-python-eggs
 WSGIScriptAlias / /opt/regluit/deploy/prod.wsgi
+# Run the app in the MAIN Python interpreter, not a mod_wsgi sub-interpreter.
+# Django 4.x template-based form rendering (RenderableMixin) misbehaves in
+# sub-interpreters: empty form error lists ({{ form.x.errors }},
+# {{ form.non_field_errors }}) stringify to a literal "[]" instead of "".
+# Reproduced on Django 4.2.21 under mod_wsgi 5.0.0 (regluit#1163); fixed by
+# forcing the global/main interpreter. Harmless for a single-app daemon and a
+# long-standing mod_wsgi best practice for C-extension/threading correctness.
+WSGIApplicationGroup %{GLOBAL}
 
 # generated using https://mozilla.github.io/server-side-tls/ssl-config-generator/
 # intermediate mode


### PR DESCRIPTION
Fixes the stray `[]` rendering in form errors across the site — **Gluejar/regluit#1163**.

## What
One line in the Apache vhost template: `WSGIApplicationGroup %{GLOBAL}`, so the WSGI app runs in the **main** Python interpreter instead of a mod_wsgi **sub-interpreter**.

## Why
Under Django 4.2.21 + mod_wsgi 5.0.0, with no `WSGIApplicationGroup` set, the app ran in a per-app sub-interpreter. Django 4.x's template-based form rendering (`RenderableMixin`) misbehaves in sub-interpreters: **empty** form error lists — `{{ form.non_field_errors }}`, `{{ field.errors }}` — stringified to a literal `[]` instead of `""`. Visible on every form (contribution/`download` page, registration, supporter profile, etc.; ~116 template spots).

## How it was root-caused (on dj42.unglue.it)
The deployed **source renders correctly** in every in-process reproduction — Django shell, test client, the real `WSGIHandler` driven directly, exact `prod.wsgi` init, with simulated traffic, and under 24 concurrent threads — all blank. Only the **live mod_wsgi daemon** rendered `[]`, freshly per request (fresh CSRF → not the Apache disk cache), surviving full restarts, on the same venv/Django. Ruled out: stale code, cache, interpreter/Django version, rogue templates, custom error class. Setting `WSGIApplicationGroup %{GLOBAL}` eliminated `[]` **site-wide** (verified: contribution page 0 brackets, register form 0 brackets, home/work pages 200).

This is also a long-standing mod_wsgi best practice (C-extension/GIL correctness) and harmless for a single-app daemon.

## Rollout
- Cherry-picked into `feature/prod-green` so the Django-4.2 cutover box gets it baked in.
- dj42 currently has the change applied **manually** to `/etc/apache2/sites-available/prod.conf` for verification; an Ansible re-deploy from this template makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
