### PR TITLE
Post-deploy: localize Site row to box's server_name (fix regluit#1164)

### DIFF
--- a/roles/regluit_prod/tasks/apache.yml
+++ b/roles/regluit_prod/tasks/apache.yml
@@ -84,3 +84,15 @@
     settings: "{{ django_settings_module }}"
   notify:
     - restart apache
+
+- name: Localize Site row to this box's hostname
+  # Fixes regluit#1164: snapshot-restored staging boxes inherit prod's Site row
+  # (domain='unglue.it'), causing emailed links to point at prod.
+  # server_name is the bare apex hostname (no www.) for every box, so it maps
+  # directly to the desired Site domain.  On prod (server_name=unglue.it) this
+  # is a no-op because the Site row already carries the correct domain.
+  django_manage:
+    app_path: "{{ project_path }}"
+    command: "set_site_domain {{ server_name }}"
+    virtualenv: "{{ project_path }}/venv"
+    settings: "{{ django_settings_module }}"

--- a/roles/regluit_prod/tasks/apache.yml
+++ b/roles/regluit_prod/tasks/apache.yml
@@ -89,10 +89,17 @@
   # Fixes regluit#1164: snapshot-restored staging boxes inherit prod's Site row
   # (domain='unglue.it'), causing emailed links to point at prod.
   # server_name is the bare apex hostname (no www.) for every box, so it maps
-  # directly to the desired Site domain.  On prod (server_name=unglue.it) this
-  # is a no-op because the Site row already carries the correct domain.
+  # directly to the desired Site domain.
+  # Guarded off on production: prod's Site row is already correct, so this makes
+  # "never mutate prod's Site row" a hard guarantee rather than a no-op-by-luck
+  # (Codex review 2026-06-16).
   django_manage:
     app_path: "{{ project_path }}"
     command: "set_site_domain {{ server_name }}"
     virtualenv: "{{ project_path }}/venv"
     settings: "{{ django_settings_module }}"
+  register: set_site_domain_result
+  # The command prints "Updated Site ..." only when it actually wrote to the DB;
+  # otherwise it prints a "no-op" line. Report changed only on a real write.
+  changed_when: "'Updated Site' in (set_site_domain_result.out | default(''))"
+  when: server_name != "unglue.it"


### PR DESCRIPTION
Fixes regluit#1164 — staging boxes restored from a prod snapshot keep prod's Site row (domain='unglue.it'), so every emailed link points at production instead of the staging box. This adds a post-deploy step that self-localizes the Site row to the box's own hostname on every deploy.

## What changed

- **`roles/regluit_prod/tasks/apache.yml`** — one new `django_manage` task appended after `Migrate database`:

```yaml
- name: Localize Site row to this box's hostname
  django_manage:
    app_path: "{{ project_path }}"
    command: "set_site_domain {{ server_name }}"
    virtualenv: "{{ project_path }}/venv"
    settings: "{{ django_settings_module }}"
```

## What `server_name` contains (verified in group_vars)

| Group | `server_name` | Effect |
|-------|--------------|--------|
| `production` | `unglue.it` | no-op (Site already correct) |
| `batterup` | `unglue.it` | no-op |
| `ondeck` | `ondeck.unglue.it` | localizes |
| `dev` | `m.unglue.it` | localizes |
| any future staging box | e.g. `dj42.unglue.it` | localizes |

`server_name` is always the bare apex host — no `www.` prefix — so it maps directly to the desired `Site.domain`.

## Why it's a no-op on prod

`server_name=unglue.it` on the production group.  The management command detects that the Site row already carries `"unglue.it"` and exits cleanly without writing to the DB.

## Why it's idempotent

Re-running `set_site_domain <same value>` prints "no-op" and returns without touching the DB (guard inside the command).

## Requires

The `set_site_domain` management command shipped in Gluejar/regluit#1166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)