### PR TITLE
deploy.yml: configurable target + wire test.unglue.it (test-first staging deploys)

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -28,6 +28,8 @@
 #   ansible-playbook -i hosts deploy.yml -e run_collectstatic=true
 #   ansible-playbook -i hosts deploy.yml --check --diff       # dry run first
 #   ansible-playbook -i hosts deploy.yml -e git_branch=hotfix/x   # ad-hoc branch
+#   ansible-playbook -i hosts deploy.yml -e deploy_target=regluit-test   # deploy to test.unglue.it
+#   ansible-playbook -i hosts deploy.yml -e deploy_target=regluit-test -e git_branch=hotfix/x  # test a branch on staging
 #
 #   Target host + branch come from group_vars/production (git_branch: "production").
 #
@@ -35,7 +37,7 @@
 #   Re-run with -e git_branch=<previous tag/SHA/branch>, or (blue/green) flip the
 #   Elastic IP back to blue. This playbook is idempotent and reversible.
 
-- hosts: regluit-prod
+- hosts: "{{ deploy_target | default('regluit-prod') }}"
   gather_facts: false
 
   vars:

--- a/group_vars/test/vars.yml
+++ b/group_vars/test/vars.yml
@@ -1,0 +1,14 @@
+---
+### Variables for the test.unglue.it staging server (deploy.yml / code-only) ###
+### Intentionally minimal & vault-free: deploy.yml does git checkout + restart   ###
+### only (no settings render / DB / certs), so no secret vars are needed here.    ###
+
+project_path: "/opt/regluit"
+django_settings_module: "regluit.settings.prod"
+user_name: "ubuntu"
+git_repo: "https://github.com/Gluejar/regluit.git"
+git_branch: "master"
+
+# Non-production environment: suppress error emails to prod admins.
+# See EbookFoundation/security-private#11.
+disable_admin_emails: true

--- a/hosts
+++ b/hosts
@@ -4,3 +4,5 @@ regluit-dev ansible_host=m.unglue.it ansible_user=ubuntu ansible_python_interpre
 regluit-ondeck ansible_host=ondeck.unglue.it ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3
 [production]
 regluit-prod ansible_host=unglue.it ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3
+[test]
+regluit-test ansible_host=test.unglue.it ansible_user=ubuntu ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
Makes `deploy.yml` target-configurable (`deploy_target`, default `regluit-prod` — backward compatible) and adds `test.unglue.it` as a first-class deploy target (`[test]` inventory group + minimal vault-free `group_vars/test`).

Enables the **test-first** flow: `ansible-playbook -i hosts deploy.yml -e deploy_target=regluit-test -e git_branch=hotfix/x` → validate on staging → promote to prod.

Used today to validate the `/accounts/register/` fix (Gluejar/regluit#1182) on test before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)