### PR TITLE
Harden against OOM: activate mod_wsgi daemon mode + maximum-requests + swap + memory alert (refs Gluejar/regluit#1078)

### DIFF
--- a/roles/regluit_prod/tasks/apache.yml
+++ b/roles/regluit_prod/tasks/apache.yml
@@ -14,6 +14,7 @@
 
 - name: Create apache config
   become: yes
+  tags: [apache-config, oom-hardening]
   template:
     src: apache.conf.j2
     dest: "/etc/apache2/sites-available/prod.conf"

--- a/roles/regluit_prod/tasks/cron.yml
+++ b/roles/regluit_prod/tasks/cron.yml
@@ -3,16 +3,22 @@
 # See: https://github.com/Gluejar/regluit/issues/1111 (disk/log management)
 # See: https://github.com/Gluejar/regluit/issues/1078 (bot traffic)
 
-# Workaround for memory pressure under heavy bot traffic
-# TODO: Remove once proper bot mitigation is in place (see issue #1078)
-- name: Restart Apache periodically (workaround for bot load)
+# REMOVED: the periodic `service apache2 restart` band-aid (Gluejar/regluit#1078).
+# Forensics on the 2026-06-22 OOM showed systemd's SIGKILL does NOT reap the
+# mod_wsgi daemon processes ("Unit process ... remains running after unit stopped",
+# "Found left-over process ... Ignoring"). Each restart spawned fresh workers while
+# the bloated old ones survived, accumulating to ~13.3 GB across ~6 orphaned workers
+# before the OOM. Proper, clean recycling is now handled by WSGIDaemonProcess
+# maximum-requests (see templates/apache.conf.j2), so this cron is not merely
+# unnecessary, it was actively harmful. state: absent removes it from any
+# already-provisioned box.
+- name: Remove obsolete apache-restart workaround cron
   become: yes
   ansible.builtin.cron:
     name: "apache-restart-workaround"
-    minute: "9,29,49"
-    hour: "*"
-    job: "service apache2 restart"
+    state: absent
     user: root
+  tags: [apache-restart-cleanup, oom-hardening]
 
 # Apache access logs can reach 1GB/day under bot traffic.
 # cronolog creates dated files but doesn't clean them up.

--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -114,6 +114,7 @@
 
 - name: Configure swap (memory-pressure cushion)
   import_tasks: swap.yml
+  tags: [swap, oom-hardening]
 
 - name: Run redis tasks
   import_tasks: redis.yml
@@ -135,6 +136,7 @@
 
 - name: Run monitoring tasks (memory alert)
   import_tasks: monitoring.yml
+  tags: [monitoring, oom-hardening]
 
 - name: Run log management tasks
   import_tasks: log_management.yml

--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -112,6 +112,9 @@
     - '80'
     - '443'
 
+- name: Configure swap (memory-pressure cushion)
+  import_tasks: swap.yml
+
 - name: Run redis tasks
   import_tasks: redis.yml
 
@@ -129,6 +132,9 @@
 
 - name: Run cron tasks
   import_tasks: cron.yml
+
+- name: Run monitoring tasks (memory alert)
+  import_tasks: monitoring.yml
 
 - name: Run log management tasks
   import_tasks: log_management.yml

--- a/roles/regluit_prod/tasks/monitoring.yml
+++ b/roles/regluit_prod/tasks/monitoring.yml
@@ -1,0 +1,21 @@
+---
+# Lightweight memory-pressure alerting (Gluejar/regluit#1078).
+# Emails admins when MemAvailable falls below a threshold so an impending OOM
+# wedge is caught early, instead of being discovered when the site is already down.
+
+- name: Install memory-alert script
+  become: yes
+  template:
+    src: mem_alert.sh.j2
+    dest: /usr/local/sbin/mem_alert.sh
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Schedule memory-alert check (every 5 min)
+  become: yes
+  ansible.builtin.cron:
+    name: "mem-alert"
+    minute: "*/5"
+    job: "/usr/local/sbin/mem_alert.sh"
+    user: root

--- a/roles/regluit_prod/tasks/swap.yml
+++ b/roles/regluit_prod/tasks/swap.yml
@@ -1,14 +1,11 @@
 ---
-# Swap file — memory-pressure cushion.
-# The box has NO swap by default, so a single bloated mod_wsgi worker can drive
-# the host straight into OOM/thrash and a hard wedge (sshd can't fork, apache
-# stops). A modest swapfile lets the kernel ride out spikes and lets the
-# OOM-killer act cleanly instead of the whole box locking up.
-# See Gluejar/regluit#1078 (memory pressure under bot/heavy traffic).
-#
-# This is a *cushion*, not the cure — the real fix is bounding worker growth
-# (WSGIDaemonProcess maximum-requests, see templates/apache.conf.j2). Keep
-# swappiness low so RAM stays primary and swap is used only under pressure.
+# Swap file — memory-pressure cushion (Gluejar/regluit#1078).
+# The box has NO swap by default, so a memory spike goes straight to OOM/thrash
+# and a hard wedge. A modest swapfile lets the kernel ride out spikes and the
+# OOM-killer act cleanly. This is a *cushion*, not the cure — the real fix is
+# daemon-mode worker recycling (WSGIDaemonProcess maximum-requests + the
+# WSGIProcessGroup delegation in templates/apache.conf.j2). Keep swappiness low
+# so RAM stays primary and swap is used only under pressure.
 
 - name: Create swap file ({{ swap_file_size_mb | default(4096) }} MB)
   become: yes
@@ -24,23 +21,30 @@
     group: root
     mode: "0600"
 
+# Idempotent format: only mkswap if the file has no swap signature yet.
+- name: Detect existing swap signature
+  become: yes
+  command: "blkid -p -s TYPE -o value {{ swap_file_path | default('/swapfile') }}"
+  register: swap_blkid
+  changed_when: false
+  failed_when: false
+
 - name: Format swap file
   become: yes
   command: "mkswap {{ swap_file_path | default('/swapfile') }}"
-  register: mkswap_result
-  changed_when: "'Setting up swapspace' in mkswap_result.stdout"
-  failed_when:
-    - mkswap_result.rc != 0
-    - "'already' not in mkswap_result.stderr"
+  when: "'swap' not in (swap_blkid.stdout | default(''))"
+
+# Idempotent activation: only swapon if this file isn't already an active swap.
+- name: Check active swap devices
+  become: yes
+  command: "swapon --show=NAME --noheadings"
+  register: swap_active
+  changed_when: false
 
 - name: Enable swap file now
   become: yes
   command: "swapon {{ swap_file_path | default('/swapfile') }}"
-  register: swapon_result
-  changed_when: swapon_result.rc == 0
-  failed_when:
-    - swapon_result.rc != 0
-    - "'already active' not in (swapon_result.stderr | lower)"
+  when: "(swap_file_path | default('/swapfile')) not in (swap_active.stdout | default(''))"
 
 - name: Persist swap in /etc/fstab
   become: yes

--- a/roles/regluit_prod/tasks/swap.yml
+++ b/roles/regluit_prod/tasks/swap.yml
@@ -1,0 +1,60 @@
+---
+# Swap file — memory-pressure cushion.
+# The box has NO swap by default, so a single bloated mod_wsgi worker can drive
+# the host straight into OOM/thrash and a hard wedge (sshd can't fork, apache
+# stops). A modest swapfile lets the kernel ride out spikes and lets the
+# OOM-killer act cleanly instead of the whole box locking up.
+# See Gluejar/regluit#1078 (memory pressure under bot/heavy traffic).
+#
+# This is a *cushion*, not the cure — the real fix is bounding worker growth
+# (WSGIDaemonProcess maximum-requests, see templates/apache.conf.j2). Keep
+# swappiness low so RAM stays primary and swap is used only under pressure.
+
+- name: Create swap file ({{ swap_file_size_mb | default(4096) }} MB)
+  become: yes
+  command: "fallocate -l {{ swap_file_size_mb | default(4096) }}M {{ swap_file_path | default('/swapfile') }}"
+  args:
+    creates: "{{ swap_file_path | default('/swapfile') }}"
+
+- name: Secure swap file permissions (0600)
+  become: yes
+  ansible.builtin.file:
+    path: "{{ swap_file_path | default('/swapfile') }}"
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Format swap file
+  become: yes
+  command: "mkswap {{ swap_file_path | default('/swapfile') }}"
+  register: mkswap_result
+  changed_when: "'Setting up swapspace' in mkswap_result.stdout"
+  failed_when:
+    - mkswap_result.rc != 0
+    - "'already' not in mkswap_result.stderr"
+
+- name: Enable swap file now
+  become: yes
+  command: "swapon {{ swap_file_path | default('/swapfile') }}"
+  register: swapon_result
+  changed_when: swapon_result.rc == 0
+  failed_when:
+    - swapon_result.rc != 0
+    - "'already active' not in (swapon_result.stderr | lower)"
+
+- name: Persist swap in /etc/fstab
+  become: yes
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    line: "{{ swap_file_path | default('/swapfile') }} none swap sw 0 0"
+    regexp: "^{{ swap_file_path | default('/swapfile') | regex_escape }}\\s"
+    state: present
+
+- name: Tune vm.swappiness (prefer RAM; swap only under pressure)
+  become: yes
+  ansible.posix.sysctl:
+    name: vm.swappiness
+    value: "{{ vm_swappiness | default(10) }}"
+    state: present
+    sysctl_set: yes
+    reload: yes

--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -27,7 +27,7 @@ SSLCertificateFile    /etc/ssl/certs/{{ server_name }}.crt
 SSLCertificateKeyFile /etc/ssl/private/server.key
 SSLCertificateChainFile /etc/ssl/certs/{{ server_name }}.ca-bundle
 
-WSGIDaemonProcess regluit processes=2 threads=15 python-eggs=/tmp/regluit-python-eggs
+WSGIDaemonProcess regluit processes=2 threads=15 maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} python-eggs=/tmp/regluit-python-eggs
 WSGIScriptAlias / /opt/regluit/deploy/prod.wsgi
 # Run the app in the MAIN Python interpreter, not a mod_wsgi sub-interpreter.
 # Django 4.x template-based form rendering (RenderableMixin) misbehaves in

--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -27,8 +27,14 @@ SSLCertificateFile    /etc/ssl/certs/{{ server_name }}.crt
 SSLCertificateKeyFile /etc/ssl/private/server.key
 SSLCertificateChainFile /etc/ssl/certs/{{ server_name }}.ca-bundle
 
-WSGIDaemonProcess regluit processes=2 threads=15 maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} python-eggs=/tmp/regluit-python-eggs
-WSGIScriptAlias / /opt/regluit/deploy/prod.wsgi
+WSGIDaemonProcess regluit processes=2 threads=15 maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} graceful-timeout={{ wsgi_graceful_timeout | default(30) }} python-eggs=/tmp/regluit-python-eggs
+# Delegate the app to the "regluit" daemon process group so it runs in the
+# 2 managed daemon processes (where maximum-requests recycling applies),
+# NOT embedded in the apache mpm children. Without this the WSGIDaemonProcess
+# above is defined-but-unused and the app silently runs embedded
+# (root cause of the 2026-06-22 OOM; Gluejar/regluit#1078).
+WSGIScriptAlias / /opt/regluit/deploy/prod.wsgi process-group=regluit application-group=%{GLOBAL}
+WSGIProcessGroup regluit
 # Run the app in the MAIN Python interpreter, not a mod_wsgi sub-interpreter.
 # Django 4.x template-based form rendering (RenderableMixin) misbehaves in
 # sub-interpreters: empty form error lists (form.x.errors,

--- a/roles/regluit_prod/templates/mem_alert.sh.j2
+++ b/roles/regluit_prod/templates/mem_alert.sh.j2
@@ -4,7 +4,8 @@
 # Managed by Ansible (regluit_prod). See Gluejar/regluit#1078.
 #
 # Dedup: alerts once per low-memory episode (flag in /run, cleared on recovery
-# and on reboot) so a sustained dip doesn't spam every 5 minutes.
+# and on reboot) so a sustained dip doesn't spam every 5 minutes. The flag is set
+# only after a successful send, so a transient mail failure is retried next run.
 
 set -u
 THRESH_PCT={{ mem_alert_threshold_pct | default(12) }}
@@ -15,28 +16,34 @@ HOST=$(hostname)
 
 MT=$(awk '/^MemTotal:/{print $2}' /proc/meminfo)
 MA=$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)
-[ -n "$MT" ] && [ "$MT" -gt 0 ] || exit 0
+# Bail quietly if either reading is missing/unusable.
+[ -n "$MT" ] && [ -n "$MA" ] && [ "$MT" -gt 0 ] || exit 0
 PCT=$(( 100 * MA / MT ))
 
-if [ "$PCT" -lt "$THRESH_PCT" ]; then
-    if [ ! -f "$FLAG" ]; then
-        {
-            echo "From: $FROM"
-            echo "To: $TO"
-            echo "Subject: [unglue.it] LOW MEMORY on ${HOST}: ${PCT}% available"
-            echo
-            echo "MemAvailable is ${PCT}% (alert threshold ${THRESH_PCT}%) on ${HOST} at $(date -u)."
-            echo "This is an early warning to avoid an OOM wedge (Gluejar/regluit#1078)."
-            echo
-            echo "Top memory consumers:"
-            ps -eo pid,user,pmem,rss,comm --sort=-rss | head -12
-            echo
-            echo "free -m:"
-            free -m
-        } | /usr/sbin/sendmail -t
-        touch "$FLAG"
-    fi
-else
+if [ "$PCT" -ge "$THRESH_PCT" ]; then
     # Recovered above threshold — clear the flag so the next dip alerts again.
     rm -f "$FLAG"
+    exit 0
+fi
+
+# Below threshold: alert once per episode.
+[ -f "$FLAG" ] && exit 0
+
+if {
+        echo "From: $FROM"
+        echo "To: $TO"
+        echo "Subject: [unglue.it] LOW MEMORY on ${HOST}: ${PCT}% available"
+        echo
+        echo "MemAvailable is ${PCT}% (alert threshold ${THRESH_PCT}%) on ${HOST} at $(date -u)."
+        echo "Early warning to avoid an OOM wedge (Gluejar/regluit#1078)."
+        echo
+        echo "Top memory consumers:"
+        ps -eo pid,user,pmem,rss,comm --sort=-rss | head -12
+        echo
+        echo "free -m:"
+        free -m
+    } | /usr/sbin/sendmail -t; then
+    touch "$FLAG"          # set dedup flag ONLY after a successful send
+else
+    logger -t mem_alert "sendmail failed; will retry next run"
 fi

--- a/roles/regluit_prod/templates/mem_alert.sh.j2
+++ b/roles/regluit_prod/templates/mem_alert.sh.j2
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Memory-pressure alert — emails admins when MemAvailable drops below threshold,
+# so we hear about it BEFORE an OOM wedge (not after the site is down).
+# Managed by Ansible (regluit_prod). See Gluejar/regluit#1078.
+#
+# Dedup: alerts once per low-memory episode (flag in /run, cleared on recovery
+# and on reboot) so a sustained dip doesn't spam every 5 minutes.
+
+set -u
+THRESH_PCT={{ mem_alert_threshold_pct | default(12) }}
+FLAG=/run/mem_alert.flag
+TO="{{ mem_alert_email | default('notices@gluejar.com') }}"
+FROM="{{ default_from_email | default('notices@gluejar.com') }}"
+HOST=$(hostname)
+
+MT=$(awk '/^MemTotal:/{print $2}' /proc/meminfo)
+MA=$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)
+[ -n "$MT" ] && [ "$MT" -gt 0 ] || exit 0
+PCT=$(( 100 * MA / MT ))
+
+if [ "$PCT" -lt "$THRESH_PCT" ]; then
+    if [ ! -f "$FLAG" ]; then
+        {
+            echo "From: $FROM"
+            echo "To: $TO"
+            echo "Subject: [unglue.it] LOW MEMORY on ${HOST}: ${PCT}% available"
+            echo
+            echo "MemAvailable is ${PCT}% (alert threshold ${THRESH_PCT}%) on ${HOST} at $(date -u)."
+            echo "This is an early warning to avoid an OOM wedge (Gluejar/regluit#1078)."
+            echo
+            echo "Top memory consumers:"
+            ps -eo pid,user,pmem,rss,comm --sort=-rss | head -12
+            echo
+            echo "free -m:"
+            free -m
+        } | /usr/sbin/sendmail -t
+        touch "$FLAG"
+    fi
+else
+    # Recovered above threshold — clear the flag so the next dip alerts again.
+    rm -f "$FLAG"
+fi

--- a/setup-prod.yml
+++ b/setup-prod.yml
@@ -11,7 +11,7 @@
   - name: Gathering Facts
     setup:
 
-  - include_role: 
+  - import_role:
       name: regluit_prod
   
   


### PR DESCRIPTION
**Incident:** unglue.it OOM-wedged 2026-06-22; recovered via AWS reboot. Root cause pinned by log forensics **and** a Codex review that caught a showstopper in the first draft.

### The real root cause (corrected after Codex review)
`WSGIDaemonProcess regluit` was **defined but never used** — there was no `WSGIProcessGroup`, so Django ran **embedded in the apache mpm_event children**, which never recycle (`MaxConnectionsPerChild=0`). The `*/20 service apache2 restart` cron didn't reap them (systemd left-over processes), so workers piled up to **~13.3 GB across ~6 processes** → OOM (zero swap). Verified on the box: no `process-group` anywhere; embedded children back to ~3 GB hours after the reboot. **`maximum-requests` alone would have been inert** (it only governs daemon processes).

### Fixes
1. **Activate daemon mode (the fix):** add `WSGIProcessGroup regluit` + `process-group=regluit` on `WSGIScriptAlias` so the app runs in the 2 managed daemon processes — where **`maximum-requests=500`** (+ `inactivity-timeout=300`, `graceful-timeout=30`) actually recycles them and frees memory cleanly.
2. **Remove the broken `apache-restart` cron** (`state: absent`) — redundant + harmful.
3. **4 GB swap + `vm.swappiness=10`** — cushion (box had none). Idempotent (blkid/`swapon --show` guards).
4. **Memory-alert cron** — emails admins below 12% MemAvailable; flag set only after a successful send.

### Codex review — all blockers addressed
- ✅ daemon delegation added (was embedded) — blocker #1
- ✅ swap.yml made idempotent — blocker #3
- ✅ mem_alert sets dedup flag only on successful send — noted issue
- ⚠️ apply note (blocker #2): switching embedded→daemon needs **one full restart** to establish daemon processes (the rebooted box has no orphans to worry about); thereafter `maximum-requests` recycles with no restarts.

### Apply (tagged, minimal — no full re-provision)
```
ansible-playbook -i hosts setup-prod.yml --tags oom-hardening --check --diff   # dry run (shows prod.conf diff)
ansible-playbook -i hosts setup-prod.yml --tags oom-hardening                  # apply (one apache restart to enter daemon mode)
```
Verify after: `curl` 200; `ps` shows 2 `(wsgi:regluit)` daemon procs + small mpm children; swap active; old cron gone.

### Underlying leak — queued separately
`maximum-requests` caps the symptom; a worker reaching ~3 GB is still abnormal. Endpoint memory profiling (the suspected unbounded querysets on `/free`, `/bypub`, `/pid`, OPDS) is tracked in **Gluejar/regluit#1189**. Bot load in **#1173**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)