### PR TITLE
OOM hardening: activate mod_wsgi daemon mode on prod (reconciled template + tuned recycle + apply safety)

### DIFF
--- a/group_vars/production/vars.yml
+++ b/group_vars/production/vars.yml
@@ -14,6 +14,13 @@ git_repo: "https://github.com/Gluejar/regluit.git"
 git_branch: "production"
 le_endpoint: https://acme-v02.api.letsencrypt.org/directory
 #le_endpoint: https://acme-staging-v02.api.letsencrypt.org/directory
+# Certs are managed by certbot/Let's Encrypt, NOT by this role. apache.conf.j2
+# selects the certbot cert paths (/etc/letsencrypt/live/<server_name>/...) when
+# manage_certs is false. Verified live 2026-06-22: /etc/letsencrypt/live/unglue.it/
+# exists and the static /etc/ssl/certs/unglue.it.crt path does NOT — so this MUST
+# stay false or apache fails to start. (Was a runtime -e override at cutover; now
+# committed so master reflects production. Gluejar/regluit#1078 reconciliation.)
+manage_certs: false
 alt_server_name: "www.unglue.it"
 deploy_type: 'prod'
 

--- a/group_vars/production/vars.yml
+++ b/group_vars/production/vars.yml
@@ -10,6 +10,14 @@ user_name: "ubuntu"
 server_name: "unglue.it"
 wsgi_home: "/opt/regluit/venv"
 wsgi_python_path: "/opt/regluit/venv/bin/python3"
+# mod_wsgi daemon-mode worker recycling (Gluejar/regluit#1078, provisioning#45).
+# Tuned from prod traffic 2026-06-24: ~722 dynamic req/min across processes=2 =>
+# ~361 req/min/process. 8000 => ~22 min/process lifetime, near the proven-safe
+# cadence of the old 20-min restart band-aid but graceful/rolling. Self-regulating:
+# recycles faster under heavier load. The template default (500) would recycle every
+# ~80s here (cold-start churn) — DO NOT use the default on prod. Watch RSS/proc +
+# PID turnover after apply and retune.
+wsgi_maximum_requests: 8000
 git_repo: "https://github.com/Gluejar/regluit.git"
 git_branch: "production"
 le_endpoint: https://acme-v02.api.letsencrypt.org/directory

--- a/roles/regluit_prod/handlers/main.yml
+++ b/roles/regluit_prod/handlers/main.yml
@@ -1,4 +1,15 @@
 ---
+# Gate the restart on a config syntax check. Defined BEFORE `restart apache`
+# so it runs first (handlers fire in definition order). If apache2ctl
+# configtest fails on the freshly-rendered config, the play aborts here and
+# `restart apache` never runs — apache keeps serving the old in-memory config
+# instead of being restarted into a broken one. (Codex-recommended OOM-apply
+# safety, Gluejar/regluit#1078.)
+- name: validate apache config
+  become: yes
+  command: apache2ctl configtest
+  changed_when: false
+
 - name: restart apache
   become: yes
   service:

--- a/roles/regluit_prod/tasks/apache.yml
+++ b/roles/regluit_prod/tasks/apache.yml
@@ -21,7 +21,9 @@
     owner: "{{ user_name }}"
     group: "{{ user_name }}"
     mode: 0664
-  notify: 
+    backup: yes
+  notify:
+    - validate apache config
     - restart apache
 
 - name: Create static directory

--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -23,9 +23,16 @@ ServerAdmin info@ebookfoundation.org
 SSLEngine on
 SSLProtocol All -SSLv2 -SSLv3
 
+{% if manage_certs | default(true) %}
 SSLCertificateFile    /etc/ssl/certs/{{ server_name }}.crt
 SSLCertificateKeyFile /etc/ssl/private/server.key
 SSLCertificateChainFile /etc/ssl/certs/{{ server_name }}.ca-bundle
+{% else %}
+# Cert managed externally (e.g., by certbot's systemd timer). See the host's
+# group_vars/<env>/vars.yml comment on manage_certs for the rotation story.
+SSLCertificateFile    /etc/letsencrypt/live/{{ server_name }}/fullchain.pem
+SSLCertificateKeyFile /etc/letsencrypt/live/{{ server_name }}/privkey.pem
+{% endif %}
 
 WSGIDaemonProcess regluit processes=2 threads=15 maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} graceful-timeout={{ wsgi_graceful_timeout | default(30) }} python-eggs=/tmp/regluit-python-eggs
 # Delegate the app to the "regluit" daemon process group so it runs in the
@@ -43,6 +50,25 @@ WSGIProcessGroup regluit
 # forcing the global/main interpreter. Harmless for a single-app daemon and a
 # long-standing mod_wsgi best practice for C-extension/threading correctness.
 WSGIApplicationGroup %{GLOBAL}
+
+# --- Maintenance mode (flag-file toggle; no apache reload needed) ----------
+# ON:   sudo touch /var/www/maintenance/MAINTENANCE_ON
+# OFF:  sudo rm /var/www/maintenance/MAINTENANCE_ON
+# While the flag file exists, every request (except the maintenance page
+# itself and /static/) gets a 503 + Retry-After, served as a static page
+# with no Django/WSGI/database involvement.
+Alias /maintenance.html /var/www/maintenance/maintenance.html
+<Directory /var/www/maintenance>
+  Require all granted
+</Directory>
+RewriteEngine On
+RewriteCond /var/www/maintenance/MAINTENANCE_ON -f
+RewriteCond %{REQUEST_URI} !^/maintenance\.html$
+RewriteCond %{REQUEST_URI} !^/static/
+RewriteRule ^ - [R=503,L]
+ErrorDocument 503 /maintenance.html
+Header always set Retry-After "600" "expr=%{REQUEST_STATUS} == 503"
+# ---------------------------------------------------------------------------
 
 # generated using https://mozilla.github.io/server-side-tls/ssl-config-generator/
 # intermediate mode

--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -34,7 +34,7 @@ SSLCertificateFile    /etc/letsencrypt/live/{{ server_name }}/fullchain.pem
 SSLCertificateKeyFile /etc/letsencrypt/live/{{ server_name }}/privkey.pem
 {% endif %}
 
-WSGIDaemonProcess regluit processes=2 threads=15 maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} graceful-timeout={{ wsgi_graceful_timeout | default(30) }} python-eggs=/tmp/regluit-python-eggs
+WSGIDaemonProcess regluit processes=2 threads=15 maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} graceful-timeout={{ wsgi_graceful_timeout | default(30) }} display-name=%{GROUP} python-eggs=/tmp/regluit-python-eggs
 # Delegate the app to the "regluit" daemon process group so it runs in the
 # 2 managed daemon processes (where maximum-requests recycling applies),
 # NOT embedded in the apache mpm children. Without this the WSGIDaemonProcess

--- a/scripts/oom_apply_preflight.sh
+++ b/scripts/oom_apply_preflight.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# OOM apply pre-flight + rollback staging.  regluit-provisioning#45
+#
+# Run this as the FIRST step of the OOM daemon-mode apply, BEFORE ansible.
+# On the target host it:
+#   1. backs up the live apache config (/etc/apache2/sites-available/prod.conf)
+#      and the root crontab, timestamped (UTC);
+#   2. baseline `apache2ctl configtest`;
+#   3. stages /root/oom_rollback.sh so reversal is ONE command.
+#
+# Reversal (if the apply goes haywire):   sudo /root/oom_rollback.sh
+#   -> restores the latest pre-apply apache config + root crontab, validates,
+#      restarts apache (back to embedded mode). swap + mem-alert are left in
+#      place (harmless). The band-aid restart cron is restored with the crontab.
+#
+# Usage:  ./scripts/oom_apply_preflight.sh <host>
+#   e.g.  ./scripts/oom_apply_preflight.sh test.unglue.it     # rehearse
+#         ./scripts/oom_apply_preflight.sh unglue.it          # prod
+set -euo pipefail
+HOST="${1:?usage: $0 <host>   e.g. unglue.it | test.unglue.it}"
+KEY="${KEY:-/Volumes/ryvault1/gluejar/EC2_Keys/production.pem}"
+
+ssh -i "$KEY" -o StrictHostKeyChecking=accept-new "ubuntu@$HOST" 'sudo bash -s' <<'REMOTE'
+set -euo pipefail
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+CONF=/etc/apache2/sites-available/prod.conf
+
+echo "== pre-flight backups (ts=$ts) on $(hostname) =="
+cp -a "$CONF" "$CONF.bak.$ts"
+crontab -l -u root > "/root/root.crontab.bak.$ts" 2>/dev/null || :
+apache2ctl configtest
+echo "  apache  -> $CONF.bak.$ts"
+echo "  crontab -> /root/root.crontab.bak.$ts"
+
+echo "== staging /root/oom_rollback.sh =="
+cat > /root/oom_rollback.sh <<'RB'
+#!/usr/bin/env bash
+# One-command OOM rollback. Restores the LATEST pre-apply apache config + root
+# crontab, validates, and restarts apache (back to embedded mode).
+# swap + mem-alert are left in place (harmless). See regluit-provisioning#45.
+set -euo pipefail
+CONF=/etc/apache2/sites-available/prod.conf
+conf_bak=$(ls -t "$CONF".bak.* 2>/dev/null | head -1)
+cron_bak=$(ls -t /root/root.crontab.bak.* 2>/dev/null | head -1)
+[ -n "${conf_bak:-}" ] || { echo "FATAL: no $CONF.bak.* backup found"; exit 1; }
+echo ">> restoring apache config: $conf_bak"
+cp -a "$conf_bak" "$CONF"
+apache2ctl configtest
+systemctl restart apache2
+if [ -n "${cron_bak:-}" ]; then
+  echo ">> restoring root crontab (re-enables band-aid restart cron): $cron_bak"
+  crontab -u root "$cron_bak"
+fi
+echo ">> apache active? $(systemctl is-active apache2)"
+echo ">> wsgi daemon procs (expect 0 = embedded after rollback): $(ps aux | grep -c '[(]wsgi:regluit[)]')"
+echo ">> ROLLBACK COMPLETE. Verify externally: curl -I https://$(hostname -f)/ (expect 200)"
+RB
+chmod 700 /root/oom_rollback.sh
+
+echo
+echo "PRE-FLIGHT DONE on $(hostname)."
+echo "ROLLBACK IS ONE COMMAND:   sudo /root/oom_rollback.sh"
+REMOTE


### PR DESCRIPTION
Fixes the prod OOM root cause (app running mod_wsgi **embedded**; daemon pool declared but never wired up → unbounded memory, masked by a 20-min restart cron). Tracking: EbookFoundation/regluit-provisioning#45 · refs Gluejar/regluit#1078.

**What this does**
- Activates daemon mode: `WSGIProcessGroup regluit` + `process-group=` on WSGIScriptAlias + `maximum-requests` recycling.
- Reconciles `apache.conf.j2` to deployed prod first (certbot `manage_certs` conditional + maintenance block) so the apply is a clean isolated delta — **not** a TLS-reverting outage.
- 4 GB swap + `vm.swappiness=10`; mem-alert script + `*/5` cron; removes the band-aid restart cron.

**Apply safety (Codex-reviewed twice)**
- configtest-gated restart handler (bad render aborts before restart), `backup: yes`, `display-name=%{GROUP}`.
- `scripts/oom_apply_preflight.sh` stages `/root/oom_rollback.sh` → one-command reversal.

**Tuning**: `wsgi_maximum_requests=8000` for prod, derived from live traffic (~722 dynamic req/min / 2 procs ≈ 22 min/process); default 500 would recycle every ~80s.

**Validation**: full two-step procedure proven end-to-end on test.unglue.it (2 daemon procs, swap, HTTP 200, no 503s, configtest gate fired). Deploy is from merged `master` at a pinned SHA after an equivalence diff vs the validated staging commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)