### PR TITLE
wsgi: processes=4 on prod (use all 4 cores; fix daemon-mode CPU bottleneck)

### DIFF
--- a/group_vars/production/vars.yml
+++ b/group_vars/production/vars.yml
@@ -18,6 +18,12 @@ wsgi_python_path: "/opt/regluit/venv/bin/python3"
 # ~80s here (cold-start churn) — DO NOT use the default on prod. Watch RSS/proc +
 # PID turnover after apply and retune.
 wsgi_maximum_requests: 8000
+# Daemon-mode CPU parallelism. The box has 4 vCPUs; processes=2 (the inherited
+# value) GIL-caps the app at ~2 cores while 2 sit idle, causing CPU-bound
+# slowness under bot load (observed 2026-06-24: load ~4.6, 2 procs @ ~115% CPU,
+# 7-11s responses). processes=4 uses all cores, ~restoring embedded-mode
+# parallelism while keeping recycling + memory bounds. Gluejar/regluit#1078, #45.
+wsgi_processes: 4
 git_repo: "https://github.com/Gluejar/regluit.git"
 git_branch: "production"
 le_endpoint: https://acme-v02.api.letsencrypt.org/directory

--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -34,7 +34,7 @@ SSLCertificateFile    /etc/letsencrypt/live/{{ server_name }}/fullchain.pem
 SSLCertificateKeyFile /etc/letsencrypt/live/{{ server_name }}/privkey.pem
 {% endif %}
 
-WSGIDaemonProcess regluit processes=2 threads=15 maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} graceful-timeout={{ wsgi_graceful_timeout | default(30) }} display-name=%{GROUP} python-eggs=/tmp/regluit-python-eggs
+WSGIDaemonProcess regluit processes={{ wsgi_processes | default(2) }} threads={{ wsgi_threads | default(15) }} maximum-requests={{ wsgi_maximum_requests | default(500) }} inactivity-timeout={{ wsgi_inactivity_timeout | default(300) }} graceful-timeout={{ wsgi_graceful_timeout | default(30) }} display-name=%{GROUP} python-eggs=/tmp/regluit-python-eggs
 # Delegate the app to the "regluit" daemon process group so it runs in the
 # 2 managed daemon processes (where maximum-requests recycling applies),
 # NOT embedded in the apache mpm children. Without this the WSGIDaemonProcess


### PR DESCRIPTION
Follow-up to #46. Activating daemon mode at the inherited `processes=2` GIL-capped the app at ~2 of the box's **4 vCPUs** → CPU-bound slowness under bot load (load ~4.6, 2 procs @ ~115% CPU, 7-11s responses; memory healthy). Parameterizes `processes`/`threads`; sets `wsgi_processes=4` for prod. Restores embedded-level CPU parallelism, keeps recycling + memory bounds. refs #45, Gluejar/regluit#1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)