### PR TITLE
Fix dump.sh: .my.cnf deploys root-owned, unreadable by ubuntu user

### DIFF
--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -86,17 +86,20 @@
   template:
     src: "{{ item }}.j2"
     dest: "/home/{{ user_name }}/{{ item }}"
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
     mode: 0755
   with_items:
     - 'setup.sh'
     - 'dump.sh'
-    - '.my.cnf'
 
 - name: Copy mysql config file
   become: yes
   template:
     src: "{{ item }}.j2"
     dest: "/home/{{ user_name }}/{{ item }}"
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
     mode: 0600
   with_items:
     - '.my.cnf'


### PR DESCRIPTION
Eric asked (Slack): "could you fix the dump.sh script?" — it's on prod, confirmed broken.

## Root cause
`dump.sh` (the mysqldump/backup script) is real, Ansible-managed infra deployed to `/home/ubuntu/dump.sh` on prod — not something ad hoc. It depends on `~/.my.cnf` for mysqldump credentials. The "Copy mysql config file" task in `roles/regluit_prod/tasks/main.yml` has never set `owner`/`group`, so `.my.cnf` deploys as `root:root` mode `0600` — **unreadable by the `ubuntu` user** who's meant to run `dump.sh`.

Confirmed live on prod (read-only): running `dump.sh` as `ubuntu` produces
```
mysqldump: Got error: 1045: Access denied for user 'regluit'@'...' (using password: NO)
```
mysqldump silently falls back to no password when it can't read the config, and `dump.sh` ends up writing a near-empty (34-byte) `unglue.it.sql.gz` instead of erroring loudly — that's almost certainly what Eric ran into.

This is a latent bug going back to when Eric added the `.my.cnf` templating in 2022 (`git log --follow`) — it likely only worked before via root/sudo cron contexts, and started failing once run as the plain `ubuntu` login user.

## Fix
- Add `owner: "{{ user_name }}"` + `group: "{{ user_name }}"` to both template tasks (`setup.sh`/`dump.sh` and `.my.cnf`).
- Drop the redundant `.my.cnf` entry from the first (0755) task — the dedicated second task immediately re-templates it at 0600 anyway, so the first pass did nothing but add confusion.

## Test plan
- [x] YAML parses, `ansible-playbook -i hosts --syntax-check setup-prod.yml` passes
- [ ] Deploy to prod: `ansible-playbook -i hosts setup-prod.yml --tags config` (no `--diff` — renders vault secrets)
- [ ] After deploy, confirm `.my.cnf` is owned by `ubuntu` (`ls -la ~/.my.cnf`) and `./dump.sh` produces a full (not ~34-byte) `unglue.it.sql.gz`