### PR TITLE
Tag dump.sh/.my.cnf ownership tasks as config (follow-up to #49)

### DIFF
--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -92,6 +92,7 @@
   with_items:
     - 'setup.sh'
     - 'dump.sh'
+  tags: [config]
 
 - name: Copy mysql config file
   become: yes
@@ -101,6 +102,8 @@
     owner: "{{ user_name }}"
     group: "{{ user_name }}"
     mode: 0600
+  tags: [config]
+  no_log: true          # renders vault secret (mysql_db_pass) — never log content / never --diff
   with_items:
     - '.my.cnf'
 


### PR DESCRIPTION
Follow-up to #49 (merged). That fix was correct but I discovered it's inert via the standard deploy path: I ran \`ansible-playbook -i hosts setup-prod.yml --tags config\` (the no-\`--diff\` safe path used for secret-adjacent changes) and it completed clean but touched none of the edited tasks — neither had \`tags: [config]\`.

This tags both tasks \`config\`, matching the pattern #48 established for secret-rendering tasks, and adds \`no_log: true\` to the \`.my.cnf\` task since it renders \`mysql_db_pass\`.

## Test plan
- [x] \`ansible-playbook -i hosts --syntax-check setup-prod.yml\` passes
- [ ] \`ansible-playbook -i hosts setup-prod.yml --tags config\` actually reports \`changed\` on the two tasks this time
- [ ] \`.my.cnf\` ends up \`ubuntu:ubuntu\` mode 600 on prod
- [ ] \`./dump.sh\` produces a real (not ~34-byte) \`unglue.it.sql.gz\`