### PR TITLE
Enable automatic reboot for unattended-upgrades (prod)

### DIFF
--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -156,4 +156,8 @@
 - name: Run log management tasks
   import_tasks: log_management.yml
 
+- name: Run OS patching / auto-reboot policy tasks
+  import_tasks: patching.yml
+  tags: [config, patching]
+
 

--- a/roles/regluit_prod/tasks/patching.yml
+++ b/roles/regluit_prod/tasks/patching.yml
@@ -1,0 +1,44 @@
+---
+# OS security patching + automatic reboot policy.
+#
+# unattended-upgrades was already installed/enabled (Ubuntu default) and IS
+# correctly auto-installing security-origin package updates daily. The gap:
+# kernel security updates need a reboot to take effect, and there was no
+# Automatic-Reboot configured, so the box would sit in a permanent
+# "System restart required" state until a human happened to notice the
+# login banner and manually rebooted (found 2026-07-01: box was 9+ days
+# without a reboot despite a kernel security update having been installed
+# days earlier).
+#
+# Fix: a dedicated drop-in conf.d file (NOT editing the package-managed
+# 50unattended-upgrades directly — that file can be overwritten by future
+# unattended-upgrades package upgrades) that enables Automatic-Reboot at a
+# fixed low-traffic time. Window chosen to avoid the existing 3:00-3:25 UTC
+# log-cleanup cron block and the 4:30 UTC DOAB harvest cron (see cron.yml).
+
+- name: Install automatic-reboot policy for unattended-upgrades
+  become: yes
+  template:
+    src: 51-automatic-reboot.j2
+    dest: /etc/apt/apt.conf.d/51-automatic-reboot
+    owner: root
+    group: root
+    mode: "0644"
+  tags: [config]
+
+- name: Ensure unattended-upgrades service is enabled
+  become: yes
+  ansible.builtin.systemd:
+    name: unattended-upgrades
+    enabled: yes
+    state: started
+
+- name: Ensure apt-daily and apt-daily-upgrade timers are enabled
+  become: yes
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: yes
+    state: started
+  with_items:
+    - apt-daily.timer
+    - apt-daily-upgrade.timer

--- a/roles/regluit_prod/templates/51-automatic-reboot.j2
+++ b/roles/regluit_prod/templates/51-automatic-reboot.j2
@@ -1,0 +1,14 @@
+// Managed by Ansible (roles/regluit_prod/tasks/patching.yml) — do not edit by hand.
+//
+// Separate drop-in file rather than editing 50unattended-upgrades directly,
+// since that file is owned/overwritten by the unattended-upgrades package.
+//
+// unattended-upgrades already auto-installs security-origin updates daily
+// (see 50unattended-upgrades). Kernel updates need a reboot to take effect;
+// without this, the box silently sits in "restart required" indefinitely.
+// 02:00 UTC avoids the 3:00-3:25 UTC log-cleanup cron block and the 4:30 UTC
+// DOAB harvest cron (roles/regluit_prod/tasks/cron.yml).
+
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
+Unattended-Upgrade::Automatic-Reboot-Time "02:00";


### PR DESCRIPTION
Found while investigating the login-banner nag: prod was 9+ days without a reboot despite \`unattended-upgrades\` correctly auto-installing a kernel security update days earlier. \`Automatic-Reboot\` was never configured, so the box silently sat in "restart required" indefinitely. Did a one-time manual reboot to clear the backlog (verified: new kernel active, apache restarted gracefully, homepage + FAQ both 200).

This is the going-forward fix: a dedicated \`apt.conf.d\` drop-in (not editing the package-owned \`50unattended-upgrades\`) enabling \`Automatic-Reboot\` at 02:00 UTC, chosen to avoid the 3:00-3:25 UTC log-cleanup cron block and the 4:30 UTC DOAB harvest cron.

**Codex review: LGTM.** Confirmed apt.conf.d drop-in ordering/merging is safe, \`Automatic-Reboot-WithUsers "true"\` is the right call for a headless box (otherwise a stray SSH session silently defeats the whole point), and a full reboot's shutdown path is fine for celery/mysql (celeryd already has graceful stopwait).

**Follow-up Codex flagged** (tracked as part of the observability work, not blocking this PR): alert if \`/var/run/reboot-required\` exists for >24-48h, so a skipped/failed auto-reboot doesn't go silently stale the same way this one did.

## Test plan
- [x] \`ansible-playbook -i hosts --syntax-check setup-prod.yml\` passes
- [ ] Deploy \`--tags config\`, confirm drop-in file present: \`apt-config dump | grep -E '^Unattended-Upgrade::Automatic-Reboot'\`
- [ ] Confirm timers still enabled: \`systemctl list-timers 'apt-daily*'\`