### PR TITLE
Add Restart=always to celerybeat.service (was crash-silent for 5+ days)

### DIFF
--- a/roles/regluit_prod/files/celerybeat.service
+++ b/roles/regluit_prod/files/celerybeat.service
@@ -14,7 +14,7 @@ ExecStart=/bin/sh -c '"${CELERY_BIN}" -A "${CELERY_APP}" beat  \
     --pidfile="${CELERYBEAT_PID_FILE}" \
     --logfile="${CELERYBEAT_LOG_FILE}" --loglevel="${CELERYBEAT_LOG_LEVEL}" \
     "${CELERYBEAT_OPTS}"'
-
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Root cause of Eric's "could you also fix the daily metrics job?" report.

Celery Beat crashed with a SystemExit on 2026-06-26 13:25 UTC (during an internal shutdown/atexit sequence, likely incidental to that week's OOM/Stripe-rotation deploy activity) and never came back. \`celerybeat.service\` had **no \`Restart=\` directive at all** — unlike \`celeryd.service\` (the worker), which already has \`Restart=always\`. So systemd never attempted to restart it; it just sat dead for 5+ days until an unrelated OS reboot (today, for the kernel-patching fix) restarted it as a side effect of being enabled at boot.

**Verified end-to-end**, not just "the process is running now": manually triggered \`regluit.frontend.tasks.save_info_page\`, status \`SUCCESS\`, produced \`metrics-2026-07-01.html\` (21KB, consistent with prior daily files). The Jun 27–Jul 1 gap was never backfilled — these are point-in-time snapshots, not cumulative, so there's nothing to recover.

**Codex review: LGTM.**
> Adding \`Restart=always\`... is the right minimal fix, and it matches the existing worker precedent at celeryd.service... \`always\` [is more correct than \`on-failure\`] because your incident may have looked like a clean SystemExit.

Optional non-blocking follow-up Codex suggested: \`RestartSec=5s\` (systemd's default retry delay is only 100ms) — not added here to keep this a minimal, obviously-correct hotfix.

## Test plan
- [x] Manually verified the underlying task/pipeline works (see above)
- [ ] Deploy, confirm \`systemctl cat celerybeat.service\` shows \`Restart=always\`
- [ ] Confirm \`systemctl show celerybeat -p Restart\` reports \`always\`