### PR TITLE
Observability: alert on the 3 silent-failure patterns found 2026-07-01

### DIFF
--- a/roles/regluit_prod/tasks/monitoring.yml
+++ b/roles/regluit_prod/tasks/monitoring.yml
@@ -19,3 +19,63 @@
     minute: "*/5"
     job: "/usr/local/sbin/mem_alert.sh"
     user: root
+
+# --- 2026-07-01 observability additions ---
+# Three silent-failure patterns surfaced in one incident this session (dump.sh
+# writing an empty backup, the box going 9+ days without a needed reboot,
+# celery beat crashing and never restarting) -- none of which tripped existing
+# monitoring, because the site kept responding 200 the whole time. These three
+# checks target exactly those gaps.
+
+- name: Install celery beat/worker aliveness alert script
+  become: yes
+  template:
+    src: celery_alert.sh.j2
+    dest: /usr/local/sbin/celery_alert.sh
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Schedule celery aliveness check (every 5 min)
+  become: yes
+  ansible.builtin.cron:
+    name: "celery-alert"
+    minute: "*/5"
+    job: "/usr/local/sbin/celery_alert.sh"
+    user: root
+
+- name: Install stale reboot-required alert script
+  become: yes
+  template:
+    src: reboot_required_alert.sh.j2
+    dest: /usr/local/sbin/reboot_required_alert.sh
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Schedule stale reboot-required check (hourly)
+  become: yes
+  ansible.builtin.cron:
+    name: "reboot-required-alert"
+    minute: "45"
+    hour: "*"
+    job: "/usr/local/sbin/reboot_required_alert.sh"
+    user: root
+
+- name: Install nightly DB dump + sanity check script
+  become: yes
+  template:
+    src: dump_check.sh.j2
+    dest: /usr/local/sbin/dump_check.sh
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Schedule nightly DB dump + sanity check (05:15 UTC)
+  become: yes
+  ansible.builtin.cron:
+    name: "dump-check"
+    minute: "15"
+    hour: "5"
+    user: "{{ user_name }}"
+    job: "/usr/local/sbin/dump_check.sh"

--- a/roles/regluit_prod/templates/celery_alert.sh.j2
+++ b/roles/regluit_prod/templates/celery_alert.sh.j2
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Celery beat/worker aliveness alert — emails admins if either service is not
+# active, so a crash is caught within minutes instead of by accident days later.
+# Managed by Ansible (regluit_prod). Born from the 2026-07-01 incident: celery
+# beat crashed 2026-06-26 (SystemExit, no Restart= policy configured) and sat
+# dead for 5+ days undetected — every scheduled job (metrics, notifications,
+# campaign status updates) silently stopped firing. See
+# Gluejar/regluit-provisioning#53 (the Restart=always fix) — this alert is the
+# backstop in case a future failure mode isn't caught by that fix either.
+#
+# Dedup: alerts once per down-episode (flag in /run, cleared on recovery/reboot).
+
+set -u
+FLAG=/run/celery_alert.flag
+TO="{{ mem_alert_email | default('notices@gluejar.com') }}"
+FROM="{{ default_from_email | default('notices@gluejar.com') }}"
+HOST=$(hostname)
+
+DOWN=""
+for svc in celerybeat celeryd; do
+    systemctl is-active --quiet "$svc" || DOWN="$DOWN $svc"
+done
+
+if [ -z "$DOWN" ]; then
+    rm -f "$FLAG"
+    exit 0
+fi
+
+[ -f "$FLAG" ] && exit 0
+
+if {
+        echo "From: $FROM"
+        echo "To: $TO"
+        echo "Subject: [unglue.it] Celery service(s) DOWN on ${HOST}:${DOWN}"
+        echo
+        echo "The following celery service(s) are not active on ${HOST} at $(date -u):${DOWN}"
+        echo "This means scheduled jobs (daily metrics, expiring-account notices,"
+        echo "campaign status updates, etc.) are NOT running."
+        echo
+        for svc in celerybeat celeryd; do
+            echo "--- systemctl status $svc ---"
+            systemctl status "$svc" --no-pager -l | head -15
+            echo
+        done
+    } | /usr/sbin/sendmail -t; then
+    touch "$FLAG"
+else
+    logger -t celery_alert "sendmail failed; will retry next run"
+fi

--- a/roles/regluit_prod/templates/dump.sh.j2
+++ b/roles/regluit_prod/templates/dump.sh.j2
@@ -1,10 +1,33 @@
 #!/bin/bash
+# Dump the production DB to a gzipped SQL file. Only replaces the previous
+# good dump on success -- a failed mysqldump no longer silently overwrites a
+# working backup with an empty/partial one. Closes the remaining gap from
+# Gluejar/regluit-provisioning#49/#50 (a credentials-permission bug caused
+# silent near-empty dumps for an unknown period): that fixed the permission
+# bug itself, but mysqldump's exit code was still never checked, so a
+# *different* future failure could still silently clobber a good backup.
+set -u
 HOST={{ mysql_db_host }}
 USER={{ mysql_db_user }}
 DATABASE={{ mysql_db_name }}
 DB_FILE=unglue.it.sql
+TMP_FILE="${DB_FILE}.tmp"
 
 echo "Dump all"
-mysqldump --hex-blob --host=${HOST} --user=${USER}  --single-transaction --no-tablespaces --column-statistics=0 --set-gtid-purged=OFF ${DATABASE} > ${DB_FILE}
+mysqldump --hex-blob --host=${HOST} --user=${USER} --single-transaction --no-tablespaces --column-statistics=0 --set-gtid-purged=OFF ${DATABASE} > "${TMP_FILE}"
+RC=$?
+
+if [ $RC -ne 0 ]; then
+    echo "mysqldump failed (exit ${RC}) -- leaving previous good dump in place"
+    rm -f "${TMP_FILE}"
+    exit $RC
+fi
+
 echo "gzip the file"
-gzip -f ${DB_FILE}
+if ! gzip -c "${TMP_FILE}" > "${TMP_FILE}.gz"; then
+    echo "gzip failed -- leaving previous good dump in place"
+    rm -f "${TMP_FILE}" "${TMP_FILE}.gz"
+    exit 1
+fi
+rm -f "${TMP_FILE}"
+mv "${TMP_FILE}.gz" "${DB_FILE}.gz"

--- a/roles/regluit_prod/templates/dump_check.sh.j2
+++ b/roles/regluit_prod/templates/dump_check.sh.j2
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Nightly DB dump + sanity check. Runs dump.sh (the same script Eric/Raymond
+# run by hand) as a real automated backup, and alerts if the resulting file is
+# suspiciously small OR wasn't actually refreshed this run. Born from the
+# 2026-06/07 incident: dump.sh silently wrote a ~34-byte (essentially empty)
+# backup for an unknown length of time, due to a credentials-file permission
+# bug (Gluejar/regluit-provisioning#49/#50). A healthy dump is 300MB+; anything
+# under the floor -- or a file that wasn't touched this run -- almost
+# certainly means mysqldump failed again (auth, connectivity, disk space,
+# etc.) while a stale prior-night file sat there looking fine.
+#
+# Runs as {{ user_name }} (not root) deliberately -- that's the exact context
+# the permission bug only manifested under, so this exercises the real path.
+# The flag/lock files therefore live under this user's home dir, NOT /run
+# (which a non-root user can't write into).
+#
+# NOTE (acknowledged design gap, not fixed here): this is a freshness/sanity
+# check on a single overwritten local file, not a real backup retention
+# strategy -- there is exactly one dump on disk at any time, on the same box
+# as the data it backs up. Rotation / off-host copy is a follow-up, not in
+# scope for this fix.
+#
+# Dedup: alerts once per bad-dump episode (flag cleared on the next good dump).
+# Lock: flock prevents two overlapping runs (e.g. a slow dump + cron overlap).
+
+set -u
+MIN_SIZE_BYTES={{ dump_min_size_bytes | default(10000000) }}
+HOME_DIR="/home/{{ user_name }}"
+DUMP_FILE="${HOME_DIR}/unglue.it.sql.gz"
+LOG_FILE="${HOME_DIR}/dump_check.log"
+FLAG="${HOME_DIR}/.dump_check_alert.flag"
+LOCK_FILE="${HOME_DIR}/.dump_check.lock"
+TO="{{ mem_alert_email | default('notices@gluejar.com') }}"
+FROM="{{ default_from_email | default('notices@gluejar.com') }}"
+HOST=$(hostname)
+
+if ! exec 200>"$LOCK_FILE"; then
+    logger -t dump_check_alert "could not open lock file $LOCK_FILE -- skipping run"
+    exit 1
+fi
+flock -n 200 || exit 0   # a previous run is still in progress; skip this one
+
+START=$(date +%s)
+cd "$HOME_DIR" && ./dump.sh >"$LOG_FILE" 2>&1
+DUMP_RC=$?
+
+SIZE=$(stat -c %s "$DUMP_FILE" 2>/dev/null || echo 0)
+MTIME=$(stat -c %Y "$DUMP_FILE" 2>/dev/null || echo 0)
+FRESH=0
+[ "$MTIME" -ge "$START" ] && FRESH=1
+
+if [ "$DUMP_RC" -eq 0 ] && [ "$SIZE" -ge "$MIN_SIZE_BYTES" ] && [ "$FRESH" -eq 1 ]; then
+    rm -f "$FLAG"
+    exit 0
+fi
+
+[ -f "$FLAG" ] && exit 0
+
+if {
+        echo "From: $FROM"
+        echo "To: $TO"
+        echo "Subject: [unglue.it] dump.sh failed or produced a bad backup on ${HOST}"
+        echo
+        echo "dump.sh run at $(date -u) on ${HOST}: exit=${DUMP_RC}, size=${SIZE} bytes"
+        echo "(floor ${MIN_SIZE_BYTES}), file-refreshed-this-run=${FRESH}."
+        echo
+        echo "If file-refreshed=0, the dump command failed before writing anything new"
+        echo "and you're looking at a STALE file from a previous successful night --"
+        echo "this is the same failure signature as the 2026-06/07 credentials-"
+        echo "permission bug (Gluejar/regluit-provisioning#49/#50)."
+        echo
+        echo "dump.sh output:"
+        cat "$LOG_FILE"
+    } | /usr/sbin/sendmail -t; then
+    touch "$FLAG"
+else
+    logger -t dump_check_alert "sendmail failed; will retry next run"
+fi

--- a/roles/regluit_prod/templates/reboot_required_alert.sh.j2
+++ b/roles/regluit_prod/templates/reboot_required_alert.sh.j2
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Stale reboot-required alert — emails admins if /var/run/reboot-required has
+# existed longer than a threshold, meaning unattended-upgrades' Automatic-Reboot
+# (Gluejar/regluit-provisioning#52) didn't fire or was skipped, and a security
+# patch (often kernel) is sitting installed-but-inactive. Born from the
+# 2026-07-01 incident: the box went 9+ days without a reboot after a kernel
+# security update, with nobody noticing until the login banner was read by hand.
+#
+# Dedup: alerts once per stale-episode (flag in /run, cleared when the reboot
+# finally happens and reboot-required disappears, or on our own reboot).
+
+set -u
+THRESH_HOURS={{ reboot_required_alert_threshold_hours | default(30) }}
+REBOOT_FLAG=/var/run/reboot-required
+ALERT_FLAG=/run/reboot_required_alert.flag
+TO="{{ mem_alert_email | default('notices@gluejar.com') }}"
+FROM="{{ default_from_email | default('notices@gluejar.com') }}"
+HOST=$(hostname)
+
+if [ ! -f "$REBOOT_FLAG" ]; then
+    rm -f "$ALERT_FLAG"
+    exit 0
+fi
+
+AGE_SEC=$(( $(date +%s) - $(stat -c %Y "$REBOOT_FLAG") ))
+AGE_HOURS=$(( AGE_SEC / 3600 ))
+
+if [ "$AGE_HOURS" -lt "$THRESH_HOURS" ]; then
+    exit 0
+fi
+
+[ -f "$ALERT_FLAG" ] && exit 0
+
+if {
+        echo "From: $FROM"
+        echo "To: $TO"
+        echo "Subject: [unglue.it] Reboot required for ~${AGE_HOURS}h on ${HOST} -- auto-reboot may have failed"
+        echo
+        echo "${REBOOT_FLAG} has existed for ~${AGE_HOURS}h on ${HOST} (alert threshold ${THRESH_HOURS}h)."
+        echo "Automatic-Reboot is configured for 02:00 UTC daily; this age suggests it"
+        echo "either didn't fire or was deferred."
+        echo
+        echo "Packages requiring reboot:"
+        cat "${REBOOT_FLAG}.pkgs" 2>/dev/null || echo "(none listed)"
+        echo
+        echo "Manual fix if needed: sudo reboot at a safe time."
+    } | /usr/sbin/sendmail -t; then
+    touch "$ALERT_FLAG"
+else
+    logger -t reboot_required_alert "sendmail failed; will retry next run"
+fi


### PR DESCRIPTION
Three separate silent-failure patterns surfaced in one session today, none caught by existing monitoring (uptime, memory-pressure alert), because the site kept responding 200 the whole time in each case:

1. **dump.sh** silently wrote a near-empty backup — permission bug, #49/#50
2. **Prod sat 9+ days needing a reboot** after a kernel security patch — #52
3. **Celery Beat crashed and was dead for 5+ days**, no auto-restart — #53

## New checks (all following the existing `mem_alert.sh` pattern: sendmail, dedup flag cleared on recovery, template vars with sane defaults)

- **`celery_alert.sh`** — alerts if `celerybeat`/`celeryd` aren't `systemctl`-active (every 5 min)
- **`reboot_required_alert.sh`** — alerts if `/var/run/reboot-required` has been stale >30h, meaning Automatic-Reboot (#52) didn't fire or was skipped (hourly)
- **`dump_check.sh`** — runs `dump.sh` nightly at 05:15 UTC (avoiding the 02:00 reboot / 3:00-3:25 log-cleanup / 4:30 DOAB-harvest windows) and alerts if the result is undersized **or wasn't actually refreshed this run** (catches a stale prior-night file passing a naive size-only check)

**This is a genuine behavior change, not just monitoring**: `dump.sh` becomes an automated nightly backup for the first time (previously purely manual). Flagging that explicitly rather than burying it.

## Also hardens `dump.sh` itself
It never checked `mysqldump`'s own exit code — so even with the ownership bug fixed, a *different* future mysqldump failure could still silently clobber a good backup. Now writes to a temp file and only replaces the previous good dump (both the `.sql` and `.gz` steps) on success.

## Review process
Multiple rounds of Codex review — it caught and I fixed three real bugs in the first draft:
1. The `dump_check` dedup flag lived under `/run`, which the non-root cron user can't write to (would have silently broken dedup)
2. No check that the dump actually succeeded/refreshed vs. a stale-but-good file passing the check
3. No lock against overlapping runs

All three fixed and re-reviewed; final round: LGTM on the full set.

## Explicitly NOT in scope (flagged, not silently skipped)
A single overwritten local dump file is a freshness/sanity check, not real backup retention — no history, no off-host copy. Happy to open that as a follow-up if wanted.

## Opening for your review, not merging directly
Given the production-policy nature of this (new nightly cron jobs, a new automated backup, new alerting email volume) — same reasoning as why #52 should have waited for your review before merge.

## Test plan (post-deploy)
- [ ] `systemctl is-active celerybeat celeryd` both active; stop one manually, confirm alert email arrives, restart, confirm dedup clears
- [ ] Confirm cron entries: `crontab -l` shows `celery-alert`, `reboot-required-alert`, `dump-check`
- [ ] Let `dump-check` run once (or trigger manually), confirm `unglue.it.sql.gz` refreshes and no alert fires