### PR TITLE
Restore the 2026-06-11 Beat decision under Celery-5 setting names (fixes the silent 6/26 revert)

### DIFF
--- a/roles/regluit_prod/handlers/main.yml
+++ b/roles/regluit_prod/handlers/main.yml
@@ -21,3 +21,19 @@
   ansible.builtin.service:
     name: systemd-journald
     state: restarted
+
+# Celery services load Django settings at startup only. Without these
+# handlers, a settings re-render never reaches beat/workers — which is how
+# the 2026-06-26 schedule revert sat invisible until beat happened to
+# restart on 2026-07-01 (provisioning#37, regluit#1140).
+- name: restart celeryd
+  become: yes
+  ansible.builtin.service:
+    name: celeryd
+    state: restarted
+
+- name: restart celerybeat
+  become: yes
+  ansible.builtin.service:
+    name: celerybeat
+    state: restarted

--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -68,6 +68,21 @@
   no_log: true          # renders vault secrets — never log content / never --diff
   notify:
     - restart apache
+    - restart celeryd
+    - restart celerybeat
+
+# Because the render above is no_log (its diff is invisible), assert the
+# outcome we care about: the rendered file carries the 4-job Beat schedule
+# under the Celery-5 name and no ignored old-name remnant. Guards against a
+# recurrence of the silent 2026-06-26 revert (provisioning#37, regluit#1140).
+# Matches only setting NAMES — no secret values touch the log.
+- name: Verify rendered settings carry the 4-job Beat schedule (Celery-5 name)
+  shell: |
+    set -e
+    test "$(grep -c "CELERY_BEAT_SCHEDULE\['" {{ project_path }}/settings/prod.py)" -eq 4
+    ! grep -q "CELERYBEAT_SCHEDULE" {{ project_path }}/settings/prod.py
+  changed_when: false
+  tags: [config]
 
 - name: Copy key templates to keys directory
   template:
@@ -80,6 +95,8 @@
   no_log: true          # renders vault secrets (incl. STRIPE_SK) — never log / never --diff
   notify:
     - restart apache
+    - restart celeryd
+    - restart celerybeat
 
 - name: Copy sysadmin scripts to home directory
   become: yes

--- a/roles/regluit_prod/templates/prod.py.j2
+++ b/roles/regluit_prod/templates/prod.py.j2
@@ -39,9 +39,11 @@ DATABASES = {
 }
 
 # Safety check: non-production deploys must not use production database
-if '{{ deploy_type }}' != 'prod' and 'production' in DATABASES['default'].get('HOST', ''):
+# (deploy_type defaults to 'nonprod' — the SAFE direction: guard active, no
+# Beat schedule — for legacy targets like ondeck/batterup that never define it)
+if '{{ deploy_type | default('nonprod') }}' != 'prod' and 'production' in DATABASES['default'].get('HOST', ''):
     raise ImproperlyConfigured(
-        "deploy_type='{{ deploy_type }}' is connected to a production database "
+        "deploy_type='{{ deploy_type | default('nonprod') }}' is connected to a production database "
         "(HOST=%s). Non-production environments must use their own database. "
         "Check vault_mysql_db_host in group_vars." % DATABASES['default']['HOST']
     )
@@ -139,7 +141,7 @@ CELERY_BEAT_SCHEDULE = {}
 CELERY_LOG_DIR = '/var/log/celery'
 
 # decide which of the period tasks to add to the schedule
-if '{{ deploy_type }}' == 'prod':
+if '{{ deploy_type | default('nonprod') }}' == 'prod':
     # Beat schedule per RY/Eric decision 2026-06-11: only these four jobs run.
     # (emit_notices verified safe: send queue measured 0 on the 2026-06-11 prod copy.)
     CELERY_BEAT_SCHEDULE['save_info_page'] = SAVE_INFO_PAGE

--- a/roles/regluit_prod/templates/prod.py.j2
+++ b/roles/regluit_prod/templates/prod.py.j2
@@ -1,4 +1,5 @@
 # coding=utf-8
+from django.core.exceptions import ImproperlyConfigured
 from .common import *
 
 ALLOWED_HOSTS = ['.unglue.it']
@@ -37,6 +38,14 @@ DATABASES = {
     }
 }
 
+# Safety check: non-production deploys must not use production database
+if '{{ deploy_type }}' != 'prod' and 'production' in DATABASES['default'].get('HOST', ''):
+    raise ImproperlyConfigured(
+        "deploy_type='{{ deploy_type }}' is connected to a production database "
+        "(HOST=%s). Non-production environments must use their own database. "
+        "Check vault_mysql_db_host in group_vars." % DATABASES['default']['HOST']
+    )
+
 TIME_ZONE = 'America/New_York'
 
 # settings for outbout email
@@ -51,7 +60,11 @@ EMAIL_PORT = '{{ email_port }}'
 DEFAULT_FROM_EMAIL = '{{ default_from_email }}'
 
 # send celery log to Python logging
-WORKER_HIJACK_ROOT_LOGGER = False
+# NOTE: Celery 5 + config_from_object(namespace='CELERY') reads ONLY the
+# CELERY_-prefixed setting names; the old unprefixed names are silently
+# ignored (verified empirically on celery 5.4.0, 2026-07-01 — see
+# provisioning#37 / regluit#1140 for the incident this caused).
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
 # Next step to try https
 #BASE_URL = 'http://{{ server_name }}'
@@ -122,26 +135,31 @@ STATIC_ROOT = '/var/www/static'
 #CKEDITOR_UPLOAD_PREFIX = 'https://unglue.it/static/media/'
 
 # start out with nothing scheduled
-CELERYBEAT_SCHEDULE = {}
+CELERY_BEAT_SCHEDULE = {}
 CELERY_LOG_DIR = '/var/log/celery'
 
 # decide which of the period tasks to add to the schedule
 if '{{ deploy_type }}' == 'prod':
-    # update the statuses of campaigns
-    CELERYBEAT_SCHEDULE['update_active_campaign_statuses'] = UPDATE_ACTIVE_CAMPAIGN_STATUSES
-    CELERYBEAT_SCHEDULE['report_new_ebooks'] = EBOOK_NOTIFICATIONS_JOB
-    CELERYBEAT_SCHEDULE['notify_ending_soon'] = NOTIFY_ENDING_SOON_JOB
-    CELERYBEAT_SCHEDULE['update_account_statuses'] = UPDATE_ACCOUNT_STATUSES
-    CELERYBEAT_SCHEDULE['notify_expiring_accounts'] = NOTIFY_EXPIRING_ACCOUNTS
-    CELERYBEAT_SCHEDULE['refresh_acqs'] = REFRESH_ACQS_JOB
-    CELERYBEAT_SCHEDULE['refresh_acqs'] = NOTIFY_UNCLAIMED_GIFTS
-    CELERYBEAT_SCHEDULE['save_info_page'] = SAVE_INFO_PAGE
-    CELERYBEAT_SCHEDULE['periodic_cleanup'] = PERIODIC_CLEANUP
-    CELERYBEAT_SCHEDULE['emit_notices'] = EMIT_NOTICES
-    CELERYBEAT_SCHEDULE['feature_new_work'] = FEATURE_NEW_WORK
+    # Beat schedule per RY/Eric decision 2026-06-11: only these four jobs run.
+    # (emit_notices verified safe: send queue measured 0 on the 2026-06-11 prod copy.)
+    CELERY_BEAT_SCHEDULE['save_info_page'] = SAVE_INFO_PAGE
+    CELERY_BEAT_SCHEDULE['periodic_cleanup'] = PERIODIC_CLEANUP
+    CELERY_BEAT_SCHEDULE['emit_notices'] = EMIT_NOTICES
+    CELERY_BEAT_SCHEDULE['feature_new_work'] = FEATURE_NEW_WORK
+    # --- PARKED 2026-06-11 (campaign-era / unverified email senders) --------
+    # Re-enable deliberately, one at a time, after per-job verification.
+    # Audit trail: regluit#1140 (prune audit), provisioning#37 (dup-key bug).
+    #   update_active_campaign_statuses  (campaigns eliminated)
+    #   report_new_ebooks                (email; unverified recipients)
+    #   notify_ending_soon               (email; 0 campaigns ending within 7d)
+    #   update_account_statuses          (campaign-era housekeeping)
+    #   notify_expiring_accounts         (email; ~4 candidates measured)
+    #   refresh_acqs                     (never actually scheduled since Jan 2015:
+    #                                     dup-key typo ea5adba8 -- retire, don't revive)
+    #   notify_unclaimed_gifts           (email; 4 candidates; had been running
+    #                                     under the key 'refresh_acqs' since 2015)
 
-
-ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']
+CELERY_ACCEPT_CONTENT = ['json']
 
 # set -- sandbox or production Amazon FPS?
 #AMAZON_FPS_HOST = "fps.sandbox.amazonaws.com"


### PR DESCRIPTION
Fixes provisioning#37 / Gluejar/regluit#1140 — **why**: production Beat currently schedules **nothing**. The 6/26 Stripe-rotation deploy (#48) silently repainted `prod.py` from master's never-reconciled pre-cutover template, whose `CELERYBEAT_SCHEDULE` name Celery 5.4 + `config_from_object(namespace='CELERY')` ignores (verified empirically on celery 5.4.0). Since Beat's 7/1 restart: no nightly metrics (the very symptom #53 was meant to cure), no `emit_notices` deliveries.

## What happened (short version)
| Date | Event |
|---|---|
| 6/11 | RY/Eric decision: only 4 Beat jobs run; email senders parked (baked into `feature/maintenance-mode` → `feature/prod-green`) |
| 6/17 | Cutover deploys prod-green: **4-job schedule live and working** |
| 6/26 | #48 deploy from unreconciled master **silently reverts** `prod.py` (its own new `no_log` masks the diff); Beat crashes same day → the crash takes the blame |
| 7/1 | #53 resurrects Beat → it loads the reverted file → **empty schedule** (old-name setting is invisible to Celery 5) |

The scary earlier reading — "parked email jobs firing for 3 weeks" — is **wrong**: they never fired at all.

## Changes
1. **`prod.py.j2`**: 4-job schedule under `CELERY_BEAT_SCHEDULE`, Celery-5 names rendered **unconditionally** (the prod-green `celery_major_version` shim is dropped — master lacks the var, and its `default(4)` would re-render the ignored old name); parked-jobs audit block preserved verbatim from prod-green; non-prod DB safety guard restored; `CELERY_WORKER_HIJACK_ROOT_LOGGER`; `CELERY_ACCEPT_CONTENT=['json']` (the effective runtime value since cutover — old `ACCEPT_CONTENT` was ignored).
2. **Handlers**: `restart celeryd` / `restart celerybeat`; settings **and keys** renders now notify them. Celery loads Django settings at startup only — the missing notify is *why* the revert sat invisible for 5 days.
3. **Post-render assert** (names only, no secret values): rendered file must carry exactly 4 `CELERY_BEAT_SCHEDULE[` entries and zero `CELERYBEAT_SCHEDULE` remnants — because the `no_log` render's diff is invisible by design.

## Supersedes
- **#38 — do not merge**: it revives `refresh_acqs`, which the 6/11 decision retired (and which the dup-key typo had in fact kept unscheduled since Jan 2015).

## Deploy plan (after review/merge)
1. Pre-step (read-only): measure `NoticeQueueBatch` backlog on prod before `emit_notices` resumes.
2. `ansible-playbook -i hosts setup-prod.yml --tags config` → handlers restart apache + celeryd + celerybeat.
3. Verify on the box via the **running app**, not a file grep: `app.conf.beat_schedule.keys()` == the 4 jobs; `emit_notices` arrives in `w1.log` within 10 min; metrics file appears at 00:40 UTC.

## Not in this PR (deliberate)
Full master↔prod reconciliation ("provisioning #1171"), test.unglue.it config into master, and the 24.04 bootstrap fix (`setup-prod.yml` still installs python3.8) — that's PR B, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f8mDXQDLfw3A34ynseDyc