### PR TITLE
Hotfix: unbalanced quote in #55's verify task (deploy-blocking, caught pre-flight)

### DIFF
--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -77,9 +77,11 @@
 # recurrence of the silent 2026-06-26 revert (provisioning#37, regluit#1140).
 # Matches only setting NAMES — no secret values touch the log.
 - name: Verify rendered settings carry the 4-job Beat schedule (Celery-5 name)
+  # NOTE: no single-quotes anywhere in this command — a lone quote (e.g. in a
+  # grep pattern) breaks Ansible free-form arg splitting at parse time.
   shell: |
     set -e
-    test "$(grep -c "CELERY_BEAT_SCHEDULE\['" {{ project_path }}/settings/prod.py)" -eq 4
+    test "$(grep -c "CELERY_BEAT_SCHEDULE\[" {{ project_path }}/settings/prod.py)" -eq 4
     ! grep -q "CELERYBEAT_SCHEDULE" {{ project_path }}/settings/prod.py
   changed_when: false
   tags: [config]


### PR DESCRIPTION
One-line follow-up to #55: the post-render assert's grep pattern contained a lone single-quote, which fails Ansible free-form arg splitting at parse time — first deploy attempt aborted pre-flight (nothing reached prod). Pattern simplified to the quote-free `CELERY_BEAT_SCHEDULE\[` (init line has no bracket, so the count is still exactly the 4 assignments). `--syntax-check` now passes; deploying immediately after merge since prod Beat remains schedule-less until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f8mDXQDLfw3A34ynseDyc