### PR TITLE
security: no_log the prod.wsgi render (closes the last secret-task gap that leaked creds via --diff)

### DIFF
--- a/roles/regluit_prod/tasks/apache.yml
+++ b/roles/regluit_prod/tasks/apache.yml
@@ -43,6 +43,11 @@
     owner: "{{ user_name }}"
     group: "{{ user_name }}"
     mode: 0664
+  no_log: true          # renders vault secrets (host_keys: SECRET_KEY, AWS, SES,
+                        # OAuth, Turnstile) as env exports — never log / never --diff.
+                        # This was the ONE secret-rendering task missing no_log;
+                        # a `--check --diff` drift audit leaked all of them into an
+                        # AI transcript on 2026-07-01 (security-private incident).
 
 - name: Remove apache2 logrotate file
   become: yes

--- a/roles/regluit_prod/tasks/apache.yml
+++ b/roles/regluit_prod/tasks/apache.yml
@@ -41,8 +41,14 @@
     src: prod.wsgi.j2
     dest: "{{ project_path }}/deploy/prod.wsgi"
     owner: "{{ user_name }}"
-    group: "{{ user_name }}"
-    mode: 0664
+    # group www-data + 0640: prod.wsgi embeds plaintext secrets (host_keys as
+    # env exports). Was 0664 (world-readable). The mod_wsgi daemon runs as
+    # www-data (and some procs as {{ user_name }}); both are covered here —
+    # owner reads as ubuntu, daemon reads via the www-data group — with the
+    # world bit removed. Verified on prod 2026-07-01: (wsgi:regluit) procs run
+    # as both ubuntu and www-data. Mirrors the 0600 hardening on .my.cnf.
+    group: www-data
+    mode: 0640
   no_log: true          # renders vault secrets (host_keys: SECRET_KEY, AWS, SES,
                         # OAuth, Turnstile) as env exports — never log / never --diff.
                         # This was the ONE secret-rendering task missing no_log;


### PR DESCRIPTION
**Why**: `Create WSGI Script` (apache.yml) renders `host_keys` — SECRET_KEY, AWS access+secret, SES SMTP creds, Google OAuth secret, Turnstile secret — as env exports into `prod.wsgi`, but was the **one secret-rendering task in the role without `no_log`**. A `setup-prod.yml --check --diff` drift audit on 2026-07-01 consequently printed all of them into an AI session transcript (same failure class as security-private#24 that morning; CLAUDE.md rule: *never `--diff` vault-decrypted tasks without `no_log`*).

**Fix**: add `no_log: true` to that task (matches the existing guard on the prod.py / keys / .my.cnf renders).

**Exhaustive re-audit** (the check that should have preceded the audit): all four secret-rendering tasks now carry `no_log`; every other template in the role references zero secret vars (`grep -icE 'host_keys|common_keys|vault_|_pass|_secret|password|_key|access_key'` == 0 for apache.conf, setup.sh, dump.sh, mem_alert.sh, celery envs, pth files, reboot policy).

**Process fix beyond this task**: drift audits should run `--check` **only** (changed/unchanged is the question); `--diff` is opt-in per-task and only on tasks proven secret-free.

**Follow-ups (not this PR)**: (1) rotation of the exposed live creds — operational decision, RY; (2) latent bug found in the same diff — `prod.wsgi` is not re-rendered on `--tags config`, so #51's SES rotation never reached it (the box still had the old SES key in prod.wsgi) → PR B config-fidelity item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f8mDXQDLfw3A34ynseDyc