### PR TITLE
Remove DEFAULT_FILE_STORAGE from prod.py template — deploy-blocking conflict with regluit#1202 (STORAGES)

### DIFF
--- a/roles/regluit_prod/templates/prod.py.j2
+++ b/roles/regluit_prod/templates/prod.py.j2
@@ -170,9 +170,11 @@ AMAZON_FPS_HOST = "fps.amazonaws.com"
 # local settings for maintenance mode
 MAINTENANCE_MODE = False
 
-# Amazon keys to permit S3 access
-# https://console.aws.amazon.com/iam/home?region=us-east-1#/users/s3user?section=security_credentials
-DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+# S3 file storage is configured via the STORAGES dict in settings/common.py
+# (selected automatically when AWS keys are present). DEFAULT_FILE_STORAGE was
+# removed here deliberately: Django raises ImproperlyConfigured if it is set
+# alongside an explicit STORAGES (4.2), and ignores it silently on 5.1+ (which
+# would drop S3). See Gluejar/regluit#1202 / #1203.
 
 # we should suppress Google Analytics outside of production
 SHOW_GOOGLE_ANALYTICS = True


### PR DESCRIPTION
[Gluejar/regluit#1202](https://github.com/Gluejar/regluit/pull/1202) migrates file storage to the `STORAGES` dict in `settings/common.py` (required for Django 5.x). The rendered `prod.py` (this template, line 175) still sets `DEFAULT_FILE_STORAGE` **after** common.py loads:

- **Django 4.2 (today):** setting both raises `ImproperlyConfigured: DEFAULT_FILE_STORAGE/STORAGES are mutually exclusive` → **whole-site 500 at boot the moment #1202 deploys.** (Reproduced locally, exact error.)
- **Django 5.1+ (after [#1203](https://github.com/Gluejar/regluit/pull/1203)):** the line is silently ignored → S3 storage dropped.

The rendered value is identical to what common.py's `STORAGES` selects when AWS keys are present, so removal is behavior-neutral once #1202 lands.

**Deploy coordination:** merge this and deploy (`--tags config` render of prod.py) in the **same deploy window** as regluit#1202 — #1202 must not reach test or prod while the old template line is live. Found by Codex review of the Django 5.2 spike (#1203).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fm18PoiZmSo2iJGWHuVNm4