### PR TITLE
Auto-heal wedged wsgi workers (Gluejar/regluit#1204)

### DIFF
--- a/roles/regluit_prod/tasks/main.yml
+++ b/roles/regluit_prod/tasks/main.yml
@@ -168,7 +168,7 @@
 - name: Run cron tasks
   import_tasks: cron.yml
 
-- name: Run monitoring tasks (memory alert)
+- name: Run monitoring tasks (memory alert + wsgi wedge watcher)
   import_tasks: monitoring.yml
   tags: [monitoring, oom-hardening]
 

--- a/roles/regluit_prod/tasks/monitoring.yml
+++ b/roles/regluit_prod/tasks/monitoring.yml
@@ -19,3 +19,26 @@
     minute: "*/5"
     job: "/usr/local/sbin/mem_alert.sh"
     user: root
+
+# Wedged-wsgi-worker auto-heal (Gluejar/regluit#1204).
+# A daemon process whose WSGI script fails to load (import-time error during
+# django.setup()) serves nothing but 500s until killed — mod_wsgi never
+# restarts it on its own, and Django emits no error emails in this state.
+# The watcher kills such processes (mod_wsgi respawns them) and emails an alert.
+
+- name: Install wedged-wsgi-worker watcher script
+  become: yes
+  template:
+    src: wsgi_wedge_watch.sh.j2
+    dest: /usr/local/sbin/wsgi_wedge_watch.sh
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Schedule wedged-wsgi-worker check (every 2 min)
+  become: yes
+  ansible.builtin.cron:
+    name: "wsgi-wedge-watch"
+    minute: "*/2"
+    job: "/usr/local/sbin/wsgi_wedge_watch.sh"
+    user: root

--- a/roles/regluit_prod/templates/wsgi_wedge_watch.sh.j2
+++ b/roles/regluit_prod/templates/wsgi_wedge_watch.sh.j2
@@ -13,11 +13,19 @@
 # Safety properties:
 # - Only pids that BOTH appear in a "Failed to exec Python script" log line
 #   AND are still running as a '(wsgi:regluit)' daemon are killed.
-# - Pid-reuse guard: a process is only killed if it was already running BEFORE
-#   its last logged failure. A wedged process necessarily predates its own
-#   failure lines; a fresh process that merely inherited a dead worker's pid
-#   started after them, and is skipped. Unrelated (non-wsgi) pid reuse is
-#   already excluded by the cmdline check.
+# - Pid-reuse guard: a process is only killed if it was already running
+#   STRICTLY BEFORE the second of its pid's last logged failure. A wedged
+#   process keeps producing fresh failure lines on every incoming request, so
+#   by the time cron checks it, its start time is well before its last failure;
+#   a fresh process that merely inherited a dead worker's pid postdates those
+#   lines and is skipped. Comparison is at whole-second resolution, so a
+#   same-second tie is treated as "possibly healthy" and skipped (fail-safe;
+#   the next cron run re-evaluates once new failure lines have accrued).
+#   Unrelated (non-wsgi) pid reuse is already excluded by the cmdline check.
+#   Residual false-kill risk requires pid wraparound onto a new wsgi daemon
+#   within ~1s of the old one's last failure — and even then the "damage" is
+#   one graceful respawn, the same event maximum-requests recycling performs
+#   routinely.
 # - A poisoned process can never recover (Django's app registry is permanently
 #   broken after a failed populate()), so killing it is always safe; mod_wsgi's
 #   daemon manager respawns it immediately while sibling workers keep serving.
@@ -25,16 +33,25 @@
 #   events, and each is worth knowing about).
 
 set -u
-ERRLOG="/var/log/apache2/$(date +%Y%m%d)_error.log"
+# Scan today's AND yesterday's error logs (chronological order matters for the
+# "last failure" lookup below): a worker wedged just before midnight would
+# otherwise be invisible until its next failed request lands in today's file.
+ERRLOGS=""
+for D in "$(date -d yesterday +%Y%m%d)" "$(date +%Y%m%d)"; do
+    F="/var/log/apache2/${D}_error.log"
+    [ -r "$F" ] && ERRLOGS="$ERRLOGS $F"
+done
+[ -n "$ERRLOGS" ] || exit 0
 TO="{{ mem_alert_email | default('notices@gluejar.com') }}"
 FROM="{{ default_from_email | default('notices@gluejar.com') }}"
 HOST=$(hostname)
+# NB: apache.conf.j2 currently hard-codes the 'regluit' daemon group; if that
+# is ever parameterized, use the same variable in both templates.
 WSGI_GROUP="{{ wsgi_process_group | default('regluit') }}"
 
-[ -r "$ERRLOG" ] || exit 0
-
-# Distinct pids with a failed WSGI script exec in today's error log.
-PIDS=$(grep -oE "mod_wsgi \(pid=[0-9]+\): Failed to exec Python script" "$ERRLOG" \
+# Distinct pids with a failed WSGI script exec in the scanned logs.
+# shellcheck disable=SC2086  # ERRLOGS is intentionally word-split
+PIDS=$(cat $ERRLOGS | grep -oE "mod_wsgi \(pid=[0-9]+\): Failed to exec Python script" \
         | grep -oE '[0-9]+' | sort -u)
 [ -n "$PIDS" ] || exit 0
 
@@ -48,9 +65,10 @@ for PID in $PIDS; do
 
     # Pid-reuse guard: parse the timestamp of the LAST failure line for this
     # pid ("[Mon Jul 06 08:15:08.208555 2026] ...", server-local time) and skip
-    # if the running process started after it — that's a new process that
-    # inherited the pid, not the wedged one.
-    LASTFAIL_TS=$(grep -E "mod_wsgi \(pid=${PID}\): Failed to exec" "$ERRLOG" | tail -1 \
+    # unless the running process started strictly before that second — a
+    # same-second tie could be a new process that inherited the pid, so it is
+    # skipped too (fail-safe; re-evaluated on the next run).
+    LASTFAIL_TS=$(cat $ERRLOGS | grep -E "mod_wsgi \(pid=${PID}\): Failed to exec" | tail -1 \
                    | sed -E 's/^\[([A-Za-z]+ [A-Za-z]+ [0-9]+ [0-9:]+)\.[0-9]+ ([0-9]{4})\].*/\1 \2/')
     LASTFAIL_EPOCH=$(date -d "$LASTFAIL_TS" +%s 2>/dev/null || echo 0)
     if [ "$LASTFAIL_EPOCH" -eq 0 ]; then
@@ -59,13 +77,13 @@ for PID in $PIDS; do
     fi
     ETIMES=$(ps -p "$PID" -o etimes= 2>/dev/null | tr -d ' ') || continue
     START_EPOCH=$(( $(date +%s) - ${ETIMES:-0} ))
-    if [ "$START_EPOCH" -gt "$LASTFAIL_EPOCH" ]; then
-        continue   # process is newer than its pid's last failure: pid reuse, healthy
+    if [ "$START_EPOCH" -ge "$LASTFAIL_EPOCH" ]; then
+        continue   # process not strictly older than its pid's last failure: possible pid reuse, skip
     fi
 
-    FAILCOUNT=$(grep -cE "mod_wsgi \(pid=${PID}\): Failed to exec Python script" "$ERRLOG")
-    FIRSTFAIL=$(grep -m1 -E "mod_wsgi \(pid=${PID}\): Failed to exec" "$ERRLOG" | cut -d']' -f1 | tr -d '[')
-    LASTTRACE=$(grep -A20 -m1 -E "mod_wsgi \(pid=${PID}\): Exception occurred" "$ERRLOG" | tail -20)
+    FAILCOUNT=$(cat $ERRLOGS | grep -cE "mod_wsgi \(pid=${PID}\): Failed to exec Python script")
+    FIRSTFAIL=$(cat $ERRLOGS | grep -m1 -E "mod_wsgi \(pid=${PID}\): Failed to exec" | cut -d']' -f1 | tr -d '[')
+    LASTTRACE=$(cat $ERRLOGS | grep -A20 -m1 -E "mod_wsgi \(pid=${PID}\): Exception occurred" | tail -20)
 
     logger -t wsgi_wedge_watch "killing wedged wsgi daemon pid=${PID} (${FAILCOUNT} failed execs since ${FIRSTFAIL})"
     kill "$PID" 2>/dev/null || continue

--- a/roles/regluit_prod/templates/wsgi_wedge_watch.sh.j2
+++ b/roles/regluit_prod/templates/wsgi_wedge_watch.sh.j2
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Wedged-wsgi-worker watcher — detects a mod_wsgi daemon process whose WSGI
+# script failed to load (e.g. an import-time error during django.setup()) and
+# kills it so mod_wsgi respawns a fresh process. Managed by Ansible
+# (regluit_prod). See Gluejar/regluit#1204.
+#
+# Why: mod_wsgi does NOT restart a daemon process whose script failed to exec —
+# it keeps the process and answers every request with a 500 ("populate() isn't
+# reentrant") until something kills it. On 2026-07-06 one such worker 500ed
+# ~1 in 4 requests for 93 minutes. This failure mode emits NO Django error
+# emails (Django never finishes loading), so it is otherwise invisible.
+#
+# Safety properties:
+# - Only pids that BOTH appear in a "Failed to exec Python script" log line
+#   AND are still running as a '(wsgi:regluit)' daemon are killed.
+# - Pid-reuse guard: a process is only killed if it was already running BEFORE
+#   its last logged failure. A wedged process necessarily predates its own
+#   failure lines; a fresh process that merely inherited a dead worker's pid
+#   started after them, and is skipped. Unrelated (non-wsgi) pid reuse is
+#   already excluded by the cmdline check.
+# - A poisoned process can never recover (Django's app registry is permanently
+#   broken after a failed populate()), so killing it is always safe; mod_wsgi's
+#   daemon manager respawns it immediately while sibling workers keep serving.
+# - Alerts by email on every kill (no dedup needed: kills are rare one-shot
+#   events, and each is worth knowing about).
+
+set -u
+ERRLOG="/var/log/apache2/$(date +%Y%m%d)_error.log"
+TO="{{ mem_alert_email | default('notices@gluejar.com') }}"
+FROM="{{ default_from_email | default('notices@gluejar.com') }}"
+HOST=$(hostname)
+WSGI_GROUP="{{ wsgi_process_group | default('regluit') }}"
+
+[ -r "$ERRLOG" ] || exit 0
+
+# Distinct pids with a failed WSGI script exec in today's error log.
+PIDS=$(grep -oE "mod_wsgi \(pid=[0-9]+\): Failed to exec Python script" "$ERRLOG" \
+        | grep -oE '[0-9]+' | sort -u)
+[ -n "$PIDS" ] || exit 0
+
+for PID in $PIDS; do
+    # Still running AND still a wsgi daemon for our process group?
+    CMD=$(ps -p "$PID" -o cmd= 2>/dev/null) || continue
+    case "$CMD" in
+        *"(wsgi:${WSGI_GROUP})"*) ;;
+        *) continue ;;
+    esac
+
+    # Pid-reuse guard: parse the timestamp of the LAST failure line for this
+    # pid ("[Mon Jul 06 08:15:08.208555 2026] ...", server-local time) and skip
+    # if the running process started after it — that's a new process that
+    # inherited the pid, not the wedged one.
+    LASTFAIL_TS=$(grep -E "mod_wsgi \(pid=${PID}\): Failed to exec" "$ERRLOG" | tail -1 \
+                   | sed -E 's/^\[([A-Za-z]+ [A-Za-z]+ [0-9]+ [0-9:]+)\.[0-9]+ ([0-9]{4})\].*/\1 \2/')
+    LASTFAIL_EPOCH=$(date -d "$LASTFAIL_TS" +%s 2>/dev/null || echo 0)
+    if [ "$LASTFAIL_EPOCH" -eq 0 ]; then
+        logger -t wsgi_wedge_watch "could not parse failure timestamp for pid=${PID}; skipping (fail-safe)"
+        continue
+    fi
+    ETIMES=$(ps -p "$PID" -o etimes= 2>/dev/null | tr -d ' ') || continue
+    START_EPOCH=$(( $(date +%s) - ${ETIMES:-0} ))
+    if [ "$START_EPOCH" -gt "$LASTFAIL_EPOCH" ]; then
+        continue   # process is newer than its pid's last failure: pid reuse, healthy
+    fi
+
+    FAILCOUNT=$(grep -cE "mod_wsgi \(pid=${PID}\): Failed to exec Python script" "$ERRLOG")
+    FIRSTFAIL=$(grep -m1 -E "mod_wsgi \(pid=${PID}\): Failed to exec" "$ERRLOG" | cut -d']' -f1 | tr -d '[')
+    LASTTRACE=$(grep -A20 -m1 -E "mod_wsgi \(pid=${PID}\): Exception occurred" "$ERRLOG" | tail -20)
+
+    logger -t wsgi_wedge_watch "killing wedged wsgi daemon pid=${PID} (${FAILCOUNT} failed execs since ${FIRSTFAIL})"
+    kill "$PID" 2>/dev/null || continue
+
+    {
+        echo "From: $FROM"
+        echo "To: $TO"
+        echo "Subject: [unglue.it] wedged wsgi worker auto-healed on ${HOST} (pid ${PID})"
+        echo
+        echo "A mod_wsgi daemon process failed to load the WSGI script and was"
+        echo "serving 500s; wsgi_wedge_watch killed it at $(date -u) so mod_wsgi"
+        echo "respawns it. See Gluejar/regluit#1204 for the failure mode."
+        echo
+        echo "pid: ${PID}"
+        echo "failed exec attempts today: ${FAILCOUNT}"
+        echo "first failure: ${FIRSTFAIL}"
+        echo
+        echo "First logged traceback for this pid:"
+        echo "${LASTTRACE}"
+    } | /usr/sbin/sendmail -t || logger -t wsgi_wedge_watch "sendmail failed for pid=${PID} alert"
+done

--- a/roles/regluit_prod/templates/wsgi_wedge_watch.sh.j2
+++ b/roles/regluit_prod/templates/wsgi_wedge_watch.sh.j2
@@ -98,7 +98,7 @@ for PID in $PIDS; do
         echo "respawns it. See Gluejar/regluit#1204 for the failure mode."
         echo
         echo "pid: ${PID}"
-        echo "failed exec attempts today: ${FAILCOUNT}"
+        echo "failed exec attempts (scanned logs): ${FAILCOUNT}"
         echo "first failure: ${FIRSTFAIL}"
         echo
         echo "First logged traceback for this pid:"

--- a/tests/wsgi_wedge_watch/run_tests.sh
+++ b/tests/wsgi_wedge_watch/run_tests.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Test harness for wsgi_wedge_watch.sh — runs inside ubuntu container.
+# Mocks: ps, logger (PATH shims), kill (exported function — PATH can't shadow a
+# bash builtin) + /usr/sbin/sendmail. Real: grep/sed/date/cat.
+set -u
+cd /work
+FIXDATE=$(date +"%a %b %d")           # today
+YDATE=$(date -d yesterday +"%a %b %d")
+YEAR=$(date +%Y)
+mkdir -p mockbin evidence
+export EVID=/work/evidence
+
+# ---- fixture error logs ----
+LOGDIR=/var/log/apache2; mkdir -p $LOGDIR
+LOG="$LOGDIR/$(date +%Y%m%d)_error.log"
+YLOG="$LOGDIR/$(date -d yesterday +%Y%m%d)_error.log"
+
+emit_failure() { # $1=file $2=datestr $3=time $4=pid
+cat >> "$1" <<EOF
+[$2 $3.208555 $YEAR] [wsgi:error] [pid $4:tid 1241] mod_wsgi (pid=$4): Failed to exec Python script file '/opt/regluit/deploy/prod.wsgi'.
+[$2 $3.208632 $YEAR] [wsgi:error] [pid $4:tid 1241] mod_wsgi (pid=$4): Exception occurred processing WSGI script '/opt/regluit/deploy/prod.wsgi'.
+[$2 $3.218438 $YEAR] [wsgi:error] [pid $4:tid 1241] Traceback (most recent call last):
+[$2 $3.219840 $YEAR] [wsgi:error] [pid $4:tid 1241] ValueError: not enough values to unpack (expected 2, got 1)
+EOF
+}
+
+# pid 501: wedged today (old process, failures today)          -> KILL
+# pid 502: failures today but process dead                     -> skip
+# pid 503: failures today, young process (pid reuse)           -> skip
+# pid 505: failure timestamp == process start second (tie)     -> skip (fail-safe)
+# pid 506: wedged, failures ONLY in yesterday's log (midnight) -> KILL
+emit_failure "$LOG"  "$FIXDATE" "01:15:08" 501
+emit_failure "$LOG"  "$FIXDATE" "01:15:08" 502
+emit_failure "$LOG"  "$FIXDATE" "01:15:08" 503
+TIE_TIME=$(date +%H:%M:%S); TIE_EPOCH=$(date +%s)
+emit_failure "$LOG"  "$FIXDATE" "$TIE_TIME" 505
+emit_failure "$YLOG" "$YDATE"   "23:59:01" 506
+echo "[$FIXDATE 01:15:09.000000 $YEAR] [mpm_event:notice] [pid 504:tid 1] AH00489: resuming normal operations" >> "$LOG"
+
+# ---- mocks ----
+cat > mockbin/ps <<EOF
+#!/bin/bash
+PID=\$2; FMT=\$4
+NOW=\$(date +%s)
+case "\$PID" in
+  501) [ "\$FMT" = "cmd=" ] && echo "(wsgi:regluit)  -k start" || echo "  90000" ;;
+  502) exit 1 ;;
+  503) [ "\$FMT" = "cmd=" ] && echo "(wsgi:regluit)  -k start" || echo "  10" ;;
+  505) [ "\$FMT" = "cmd=" ] && echo "(wsgi:regluit)  -k start" || echo \$(( NOW - $TIE_EPOCH )) ;;
+  506) [ "\$FMT" = "cmd=" ] && echo "(wsgi:regluit)  -k start" || echo "  90000" ;;
+  *) exit 1 ;;
+esac
+EOF
+cat > mockbin/logger <<'EOF'
+#!/bin/bash
+echo "LOGGER $*" >> "$EVID/logger"
+EOF
+chmod +x mockbin/*
+kill() { echo "KILL $*" >> "$EVID/kills"; }
+export -f kill
+mkdir -p /usr/sbin
+cat > /usr/sbin/sendmail <<'EOF'
+#!/bin/bash
+cat >> "$EVID/mail"
+EOF
+chmod +x /usr/sbin/sendmail
+
+# ---- run ----
+PATH=/work/mockbin:$PATH bash /work/watch.sh
+RC=$?
+
+# ---- assertions ----
+pass=0; fail=0
+assert() { if eval "$2"; then echo "PASS: $1"; pass=$((pass+1)); else echo "FAIL: $1"; fail=$((fail+1)); fi; }
+assert "exit code 0"                       "[ $RC -eq 0 ]"
+assert "wedged pid 501 killed"             "grep -q 'KILL 501' $EVID/kills"
+assert "midnight-edge pid 506 killed"      "grep -q 'KILL 506' $EVID/kills"
+assert "exactly two kills"                 "[ \$(wc -l < $EVID/kills) -eq 2 ]"
+assert "dead pid 502 not killed"           "! grep -q 502 $EVID/kills"
+assert "reused pid 503 not killed"         "! grep -q 503 $EVID/kills"
+assert "same-second tie 505 not killed"    "! grep -q 505 $EVID/kills"
+assert "alert mail sent"                   "grep -q 'wedged wsgi worker auto-healed' $EVID/mail"
+assert "mail includes pid 501"             "grep -q 'pid: 501' $EVID/mail"
+assert "mail includes pid 506"             "grep -q 'pid: 506' $EVID/mail"
+assert "mail includes traceback"           "grep -q 'ValueError: not enough values' $EVID/mail"
+assert "syslog line written"               "grep -q 'killing wedged wsgi daemon pid=501' $EVID/logger"
+
+# ---- no-failure logs: quiet no-op ----
+: > "$EVID/kills"
+echo "[$FIXDATE 01:00:00.000000 $YEAR] [mpm_event:notice] [pid 1:tid 1] AH00489: resuming" > "$LOG"
+rm -f "$YLOG"
+PATH=/work/mockbin:$PATH bash /work/watch.sh; RC2=$?
+assert "clean log: exit 0"                 "[ $RC2 -eq 0 ]"
+assert "clean log: no kills"               "[ ! -s $EVID/kills ]"
+
+# ---- missing log files entirely ----
+rm -f "$LOG"
+PATH=/work/mockbin:$PATH bash /work/watch.sh; RC3=$?
+assert "missing logs: exit 0"              "[ $RC3 -eq 0 ]"
+
+echo; echo "RESULTS: $pass passed, $fail failed"
+[ $fail -eq 0 ]

--- a/tests/wsgi_wedge_watch/test.sh
+++ b/tests/wsgi_wedge_watch/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Host-side wrapper: renders wsgi_wedge_watch.sh.j2 with default values and runs
+# the assertion harness (run_tests.sh) inside ubuntu:24.04 (GNU userland,
+# matching prod). Usage: ./test.sh   (requires docker)
+set -eu
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TPL="$HERE/../../roles/regluit_prod/templates/wsgi_wedge_watch.sh.j2"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+sed -e "s/{{ mem_alert_email | default('notices@gluejar.com') }}/notices@gluejar.com/" \
+    -e "s/{{ default_from_email | default('notices@gluejar.com') }}/notices@gluejar.com/" \
+    -e "s/{{ wsgi_process_group | default('regluit') }}/regluit/" \
+    "$TPL" > "$WORK/watch.sh"
+bash -n "$WORK/watch.sh"
+cp "$HERE/run_tests.sh" "$WORK/run_tests.sh"
+docker run --rm -v "$WORK":/work ubuntu:24.04 bash /work/run_tests.sh


### PR DESCRIPTION
Ops-guard counterpart to [Gluejar/regluit#1204](https://github.com/Gluejar/regluit/issues/1204) / [Gluejar/regluit#1205](https://github.com/Gluejar/regluit/pull/1205) — auto-detect and heal a mod_wsgi daemon process whose WSGI script failed to load, instead of letting it serve 500s until a human notices.

## Why
On 2026-07-06, a routine worker recycle hit an import-time error (gitberg's GitHub CSV fetch returned garbage mid `django.setup()`). mod_wsgi **never restarts** a daemon process whose script failed to exec — it kept answering ~1 in 4 requests with 500 for **93 minutes**. Django emits **no error emails** in this state (it never finished loading), so Eric's error-email gauge saw nothing; the June mem-alert cron saw nothing (memory was fine). Only a human noticed.

PR #1205 removes that specific import-time fetch, but this watcher guards against the whole **class** of import-time startup failures.

## What
- `wsgi_wedge_watch.sh.j2` — installed to `/usr/local/sbin/`, cron every 2 min (root), alongside `mem_alert.sh` in `monitoring.yml` (same `monitoring`/`oom-hardening` tags).
- Scans today's apache error log for `mod_wsgi (pid=N): Failed to exec Python script`; for each pid still running as a `(wsgi:regluit)` daemon, kills it (mod_wsgi respawns immediately; sibling workers keep serving) and emails an alert (pid, failure count, first traceback) to the same address as mem-alert.

## Safety
- A poisoned process can never recover (Django's app registry is permanently broken after a failed `populate()`), so killing it costs nothing — it can only serve 500s. Residual false-kill risk is bounded to pid wraparound onto a new wsgi daemon within the same second as the old one's last failure — and the "damage" would be one graceful respawn, the same event `maximum-requests` recycling performs routinely.
- **Pid-reuse guard**: a process is killed only if it was already running *before* its pid's last logged failure. A wedged process necessarily predates its own failure lines; a fresh process that inherited a dead worker's pid postdates them and is skipped. Non-wsgi pid reuse is excluded by the cmdline check.
- Unparseable log timestamps fail safe (skip + syslog), never kill.
- Note for Eric re error-email volume as signal: this **adds** an alert email per auto-heal event; it doesn't suppress or dedupe anything.

## Testing
Committed to the repo: `tests/wsgi_wedge_watch/test.sh` renders the template and runs the harness in `ubuntu:24.04` (GNU date, matching prod) with mocked `ps`/`kill`/`sendmail` against **real log lines from the 2026-07-06 incident**: **15/15 assertions** — kills wedged pids (incl. one whose failures are only in yesterday's log); skips dead pids, pid-reuse processes, same-second ties, and healthy workers; correct alert content; quiet no-op on clean or missing logs.

## Deploy
After merge: `ansible-playbook -i hosts setup-prod.yml --tags monitoring` (idempotent; installs script + cron only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZoSkYdkKLH37tH4QbEmH7
