### PR TITLE
Apache-layer guards for 2026-07-10 crawler flood (feedback recursion trap + Tencent fleet block)

### DIFF
--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -99,6 +99,34 @@ RewriteRule ^ - [F]
 # layer. Revert = delete this stanza and rerun --tags apache-config.
 RewriteCond expr "-R '43.128.0.0/10'"
 RewriteRule ^ - [F]
+# Round 2 (same day, ~13:15 PDT): fleet shifted weight to sibling datacenter
+# ranges. All whois-verified TencentCloud/ACEVILLE or Alibaba Cloud:
+RewriteCond expr "-R '49.51.0.0/16'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '119.28.0.0/15'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '129.226.0.0/16'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '170.106.0.0/16'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '101.32.0.0/16'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '150.109.0.0/16'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '8.208.0.0/12'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '47.240.0.0/14'"
+RewriteRule ^ - [F]
+RewriteCond expr "-R '47.244.0.0/15'"
+RewriteRule ^ - [F]
+# Rogue scraper: "OAPEN-DOAB-TXT-Downloader/2.1 (personal research use)" —
+# single ISP IP, 23k req/day, wedged in the feedback trap via double-encoded
+# /password/reset/?next= chains that the recursion rules deliberately allow.
+RewriteCond %{HTTP_USER_AGENT} "OAPEN-DOAB-TXT-Downloader" [NC]
+RewriteRule ^ - [F]
+# NOT blocked (self-identified, robots.txt-honoring, modest rate — Eric's
+# call, since AI/SEO discoverability may serve the mission): GPTBot,
+# ClaudeBot, DotBot, meta-webindexer.
 # ---------------------------------------------------------------------------
 
 # generated using https://mozilla.github.io/server-side-tls/ssl-config-generator/

--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -70,6 +70,27 @@ ErrorDocument 503 /maintenance.html
 Header always set Retry-After "600" "expr=%{REQUEST_STATUS} == 503"
 # ---------------------------------------------------------------------------
 
+# --- Crawler-trap guard (2026-07-10 incident) -------------------------------
+# Every page's footer links to /feedback/?page=<current-url> — including the
+# feedback page itself, so feedback pages link to feedback-pages-about-
+# feedback-pages: an infinite, self-multiplying URL space. Bot fleets
+# (~8k IPs, spoofed desktop-Chrome UAs, ignoring robots.txt) crawled it at
+# ~60k req/hr on 2026-07-10, pegging all wsgi daemons (load avg 13-16,
+# 17-31s TTFB sitewide). Serve a cheap static 403 before WSGI/Django sees it.
+#
+# Rule 1: /feedback/ request whose query string embeds an encoded /feedback
+#         URL (any encoding depth) = recursion. First-level
+#         /feedback/?page=<some-page> from a real user still works.
+RewriteCond %{REQUEST_URI} ^/feedback/ [NC]
+RewriteCond %{QUERY_STRING} (%2F|%252F)feedback [NC]
+RewriteRule ^ - [F]
+# Rule 2 (any path): a triple-encoded slash (%25252F) in a query string means
+#         a URL nested >= 3 levels deep via ?page=/?next= chains. No link the
+#         app emits for direct human use is ever triple-encoded.
+RewriteCond %{QUERY_STRING} %25252F [NC]
+RewriteRule ^ - [F]
+# ---------------------------------------------------------------------------
+
 # generated using https://mozilla.github.io/server-side-tls/ssl-config-generator/
 # intermediate mode
 # 2015.03.04   (with Apache v 2.2.22 and OpenSSL 1.0.1 and HSTS enabled)

--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -91,6 +91,16 @@ RewriteCond %{QUERY_STRING} %25252F [NC]
 RewriteRule ^ - [F]
 # ---------------------------------------------------------------------------
 
+# --- Datacenter crawler-fleet block (2026-07-10 incident) -------------------
+# ~59% of the 2026-07-10 flood came from Tencent Cloud international ranges
+# (ACEVILLE PTE.LTD = Tencent, 43.128.0.0/10): thousands of IPs, spoofed
+# desktop-Chrome User-Agents, ignoring robots.txt, carpet-crawling /work/
+# pages at ~600 req/min and pegging all 4 cores. Cheap 403 at the apache
+# layer. Revert = delete this stanza and rerun --tags apache-config.
+RewriteCond expr "-R '43.128.0.0/10'"
+RewriteRule ^ - [F]
+# ---------------------------------------------------------------------------
+
 # generated using https://mozilla.github.io/server-side-tls/ssl-config-generator/
 # intermediate mode
 # 2015.03.04   (with Apache v 2.2.22 and OpenSSL 1.0.1 and HSTS enabled)


### PR DESCRIPTION
**Why**: On 2026-07-10 unglue.it was badly degraded — pages taking 17–31 seconds — under a bot flood. This PR contains the Apache-layer guards that fixed it (already deployed to prod during the incident, test-first; merging brings master in line with what's running).

## Plain English

Two problems stacked on top of each other:

1. **The site had a self-made crawler trap.** Every page's footer links to `/feedback/?page=<the-page-you're-on>` — including the feedback page itself. So the feedback page links to a feedback page about the feedback page, forever. Web crawlers that ignore robots.txt wandered into this infinite hall of mirrors and couldn't get out: 84,000 hits on /feedback/ in one day.

2. **Two cloud-datacenter crawler fleets were carpet-crawling everything else** — thousands of IPs belonging to Tencent Cloud and Alibaba Cloud, all pretending to be desktop Chrome browsers and ignoring robots.txt. Daily traffic doubled in a week (600k → 1.2M requests/day), every request a full Django page render, on a 4-core server.

The fix: Apache now answers the abusive traffic with an instant, nearly-free "403 Forbidden" **before** Django ever runs:
- recursive /feedback/ requests (real users clicking "Feedback" from a normal page are unaffected — only the hall-of-mirrors URLs are blocked)
- all requests from the verified Tencent and Alibaba datacenter ranges
- one rogue scraper ("OAPEN-DOAB-TXT-Downloader", 23k requests/day from a single address)

Deliberately **not** blocked: the polite, self-identified bots that honor robots.txt — GPTBot, ClaudeBot, DotBot, Meta — each only ~7 requests/min, and AI/search discoverability of a free-ebook site arguably serves the mission. (Whether to block Meta is an open question for Eric.)

**Result**: load average 18 → ~1, homepage 24s → ~1.2s, zero 500s, verified stable across 11 hourly checks.

## Verification
- 7/7 probe matrix on test.unglue.it (legit URLs 200, trap URLs 403) + replay of real prod trap URLs
- CIDR mechanism proven end-to-end on test via temporary self-IP block (403 while on, 200 after removal)
- UA block verified with spoofed-UA curl on test and prod
- Deployed via `ansible-playbook -i hosts setup-prod.yml --tags apache-config` (validate-config handler ran before restart)

Full forensics: `INCIDENT_2026-07-10_crawler_trap_flood.md` (Gluejar working dir). Root-cause app fix (stop emitting the self-referencing footer link) to follow as a regluit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZoSkYdkKLH37tH4QbEmH7