### PR TITLE
Round 3: block stale-Chrome-UA botnet (2026-07-12 surge)

### DIFF
--- a/roles/regluit_prod/templates/apache.conf.j2
+++ b/roles/regluit_prod/templates/apache.conf.j2
@@ -127,6 +127,16 @@ RewriteRule ^ - [F]
 # NOT blocked (self-identified, robots.txt-honoring, modest rate — Eric's
 # call, since AI/SEO discoverability may serve the mission): GPTBot,
 # ClaudeBot, DotBot, meta-webindexer.
+#
+# Round 3 (2026-07-12 ~23:15 PDT surge): the distributed long-tail botnet
+# (2,200+ IPs in one 8k-line log window, unblockable by CIDR) resurged and
+# pegged all 4 cores (load 17, TTFB 21-24s). Its fingerprint: spoofed
+# desktop-Chrome UAs claiming versions 103-133 — real Chrome auto-updates,
+# so a July-2026 UA claiming Chrome <134 is years stale. Genuine users in
+# the same window: Chrome 142-146 (~1% of hits). Blocks 100-133; the spared
+# bots (GPTBot/ClaudeBot/Meta/Googlebot/DotBot) do not use these UA strings.
+RewriteCond %{HTTP_USER_AGENT} "Chrome/1([0-2][0-9]|3[0-3])\." [NC]
+RewriteRule ^ - [F]
 # ---------------------------------------------------------------------------
 
 # generated using https://mozilla.github.io/server-side-tls/ssl-config-generator/


### PR DESCRIPTION
**Why**: Sunday ~11pm PT the distributed long-tail botnet (2,208 distinct IPs in one 8k-line log window — unblockable by CIDR) resurged onto /work pages and pegged all 4 cores: load 17, sitewide pages 21–24s. Already deployed to prod (test-first) during the degradation; this PR brings master in line.

## Plain English
Real Chrome updates itself, so nobody is genuinely running Chrome 103–133 in July 2026. Yet virtually all of the surge traffic claimed exactly those versions — that's the botnet's fingerprint. Genuine visitors in the same window showed Chrome 142–146 (~1% of hits). One rule: any User-Agent claiming Chrome 100–133 gets an instant, nearly-free 403 before Django runs.

**Untouched**: current Chrome/Edge users, and all the deliberately-spared bots (GPTBot, ClaudeBot, Meta, Googlebot, DotBot — none use stale Chrome UA strings).

## Result
Load 17 → 1.5 and TTFB 24s → ~1s within 7 minutes of deploy. Zero 500s during the whole episode (invisible to the error-email gauge — external monitoring/user reports would have been the only signal).

## Verification
5/5 matrix on test.unglue.it before prod: Chrome/116 & /133 → 403; Chrome/146, ClaudeBot UA, non-Chrome clients → 200. Same checks re-run against prod post-deploy.

Deployed under Raymond's standing "tighten the screw for other bots" directive during active degradation; Raymond push-notified with veto option before deploy. Context: #63, #64, `INCIDENT_2026-07-10_crawler_trap_flood.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZoSkYdkKLH37tH4QbEmH7